### PR TITLE
Correct language - use 'Sign in' instead of login

### DIFF
--- a/src/DataCollection.Shared/LocalizedStrings/Resources.Designer.cs
+++ b/src/DataCollection.Shared/LocalizedStrings/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.LocalizedStrings.
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -475,42 +475,6 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.LocalizedStrings.
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are logged in as.
-        /// </summary>
-        internal static string LoggedInTextBlock_Text {
-            get {
-                return ResourceManager.GetString("LoggedInTextBlock.Text", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Log In.
-        /// </summary>
-        internal static string LogInButton_Label {
-            get {
-                return ResourceManager.GetString("LogInButton.Label", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Login unsuccessful.
-        /// </summary>
-        internal static string LoginUnsuccessful_Title {
-            get {
-                return ResourceManager.GetString("LoginUnsuccessful_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Log Out.
-        /// </summary>
-        internal static string LogOutButton_Label {
-            get {
-                return ResourceManager.GetString("LogOutButton.Label", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Map failed to load.
         /// </summary>
         internal static string MapLoadingError_Title {
@@ -538,15 +502,6 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.LocalizedStrings.
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your device must be connected to a network to login..
-        /// </summary>
-        internal static string NoLogin_DeviceOffline_Message {
-            get {
-                return ResourceManager.GetString("NoLogin_DeviceOffline_Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Your device is not connected to a network and you do not have an offline map downloaded. Please connect to a network to load map. .
         /// </summary>
         internal static string NoMap_DeviceOffline_Message {
@@ -561,6 +516,15 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.LocalizedStrings.
         internal static string NoOnlineMode_DeviceOffline_Message {
             get {
                 return ResourceManager.GetString("NoOnlineMode_DeviceOffline_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your device must be connected to a network to sign in..
+        /// </summary>
+        internal static string NoSignIn_DeviceOffline_Message {
+            get {
+                return ResourceManager.GetString("NoSignIn_DeviceOffline_Message", resourceCulture);
             }
         }
         
@@ -633,6 +597,42 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.LocalizedStrings.
         internal static string ShowDetailButton_Tooltip {
             get {
                 return ResourceManager.GetString("ShowDetailButton_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are signed in as.
+        /// </summary>
+        internal static string SignedInTextBlock_Text {
+            get {
+                return ResourceManager.GetString("SignedInTextBlock.Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sign In.
+        /// </summary>
+        internal static string SignInButton_Label {
+            get {
+                return ResourceManager.GetString("SignInButton.Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sign in unsuccessful.
+        /// </summary>
+        internal static string SignInUnsuccessful_Title {
+            get {
+                return ResourceManager.GetString("SignInUnsuccessful_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sign Out.
+        /// </summary>
+        internal static string SignOutButton_Label {
+            get {
+                return ResourceManager.GetString("SignOutButton.Label", resourceCulture);
             }
         }
         

--- a/src/DataCollection.Shared/LocalizedStrings/Resources.resx
+++ b/src/DataCollection.Shared/LocalizedStrings/Resources.resx
@@ -144,8 +144,8 @@
   <data name="InvalidInput_Title" xml:space="preserve">
     <value>Invalid input detected</value>
   </data>
-  <data name="LoginUnsuccessful_Title" xml:space="preserve">
-    <value>Login unsuccessful</value>
+  <data name="SignInUnsuccessful_Title" xml:space="preserve">
+    <value>Sign in unsuccessful</value>
   </data>
   <data name="OperationCancelled" xml:space="preserve">
     <value>The operation was canceled.</value>
@@ -249,11 +249,11 @@
   <data name="EditRecord_Tooltip" xml:space="preserve">
     <value>Edit Record</value>
   </data>
-  <data name="LogInButton.Label" xml:space="preserve">
-    <value>Log In</value>
+  <data name="SignInButton.Label" xml:space="preserve">
+    <value>Sign In</value>
   </data>
-  <data name="LogOutButton.Label" xml:space="preserve">
-    <value>Log Out</value>
+  <data name="SignOutButton.Label" xml:space="preserve">
+    <value>Sign Out</value>
   </data>
   <data name="MoreTools_Tooltip" xml:space="preserve">
     <value>More Tools</value>
@@ -318,11 +318,11 @@
   <data name="CancelSyncButton.Content" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="LoggedInTextBlock.Text" xml:space="preserve">
-    <value>You are logged in as</value>
+  <data name="SignedInTextBlock.Text" xml:space="preserve">
+    <value>You are signed in as</value>
   </data>
-  <data name="NoLogin_DeviceOffline_Message" xml:space="preserve">
-    <value>Your device must be connected to a network to login.</value>
+  <data name="NoSignIn_DeviceOffline_Message" xml:space="preserve">
+    <value>Your device must be connected to a network to sign in.</value>
   </data>
   <data name="NoOnlineMode_DeviceOffline_Message" xml:space="preserve">
     <value>Your device must be connected to a network to work online.</value>

--- a/src/DataCollection.Shared/ViewModels/AuthViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/AuthViewModel.cs
@@ -55,18 +55,18 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
             _userName = userName;
             _oAuthRefreshToken = oAuthRefreshToken;
 
-            // Set up authentication manager to handle logins
+            // Set up authentication manager to handle signing in
             UpdateAuthenticationManager();
 
-            // test if refresh token is available and login user
+            // test if refresh token is available and sign the user in
             if (!string.IsNullOrEmpty(_oAuthRefreshToken))
             {
-                // if device is online, login user automatically
+                // if device is online, sign user in automatically
                 ConnectivityHelper.IsWebmapAccessible(_webmapURL).ContinueWith(t =>
                 {
                     if (t.Result)
                     {
-                        LoginCommand.Execute(null);
+                        SignInCommand.Execute(null);
                     }
                 });
             }
@@ -91,16 +91,16 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
             }
         }
 
-        private ICommand _logOutCommand;
+        private ICommand _signOutCommand;
 
         /// <summary>
-        /// Gets the command to log out the user
+        /// Gets the command to sign the user out
         /// </summary>
-        public ICommand LogOutCommand
+        public ICommand SignOutCommand
         {
             get
             {
-                return _logOutCommand ?? (_logOutCommand = new DelegateCommand(
+                return _signOutCommand ?? (_signOutCommand = new DelegateCommand(
                     (x) =>
                     {
                         // clear credentials
@@ -119,16 +119,16 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
             }
         }
 
-        private ICommand _loginCommand;
+        private ICommand _signInCommand;
 
         /// <summary>
-        /// Gets the command to log in the user
+        /// Gets the command to sign the user in
         /// </summary>
-        public ICommand LoginCommand
+        public ICommand SignInCommand
         {
             get
             {
-                return _loginCommand ?? (_loginCommand = new DelegateCommand(
+                return _signInCommand ?? (_signInCommand = new DelegateCommand(
                     async (x) =>
                     {
                         // if device is not online, do not proceed
@@ -136,7 +136,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                         {
                             UserPromptMessenger.Instance.RaiseMessageValueChanged(
                                 Resources.GetString("DeviceOffline_Title"),
-                                Resources.GetString("NoLogin_DeviceOffline_Message"),
+                                Resources.GetString("NoSignIn_DeviceOffline_Message"),
                                 true);
                             return;
                         }
@@ -148,7 +148,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                         }
                         catch (Exception ex)
                         {
-                            // if the token has expired, delete it and leave the user logged out
+                            // if the token has expired, delete it and leave the user signed out
                             if (ex.Message == "refresh_token expired")
                             {
                                 BroadcastMessenger.Instance.RaiseBroadcastMessengerValueChanged(null, BroadcastMessageKey.OAuthRefreshToken);
@@ -158,7 +158,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                             else if (ex.Message != Resources.GetString("OperationCancelled"))
                             {
                                 UserPromptMessenger.Instance.RaiseMessageValueChanged(
-                                    Resources.GetString("LoginUnsuccessful_Title"),
+                                    Resources.GetString("SignInUnsuccessful_Title"),
                                     ex.Message,
                                     true,
                                     ex.StackTrace);
@@ -190,7 +190,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
             }
 
             // if no refresh token, call to generate credentials
-            // otherwise if a refresh token exists, login user using the refresh token
+            // otherwise if a refresh token exists, sign user in using the refresh token
             var credential = string.IsNullOrEmpty(_oAuthRefreshToken) ?
                 await CreateNewCredential(info) :
                 await CreateCredentialFromRefreshToken(info);
@@ -209,7 +209,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
             catch (Exception ex)
             {
                 UserPromptMessenger.Instance.RaiseMessageValueChanged(
-                                Resources.GetString("LoginUnsuccessful_Title"),
+                                Resources.GetString("SignInUnsuccessful_Title"),
                                 ex.Message,
                                 true,
                                 ex.StackTrace);
@@ -264,7 +264,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
         private async Task<OAuthTokenCredential> CreateNewCredential(CredentialRequestInfo info)
         {
             // HACK: portal endpoints that do not contain "sharing/rest" generate ArcGISTokenCredential instead of OAuthTokenCredential
-            // Forcing login into ArcGIS online if "sharing/rest" not in the service uri
+            // Forcing sing in into ArcGIS online if "sharing/rest" not in the service uri
             var serviceUri = info.ServiceUri.ToString().Contains("sharing/rest") ? info.ServiceUri : new Uri(_arcGISOnlineURL);
 
             // AuthenticationManager will handle challenging the user for credentials

--- a/src/DataCollection.Shared/ViewModels/AuthViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/AuthViewModel.cs
@@ -264,7 +264,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
         private async Task<OAuthTokenCredential> CreateNewCredential(CredentialRequestInfo info)
         {
             // HACK: portal endpoints that do not contain "sharing/rest" generate ArcGISTokenCredential instead of OAuthTokenCredential
-            // Forcing sing in into ArcGIS online if "sharing/rest" not in the service uri
+            // Forcing sign in into ArcGIS online if "sharing/rest" not in the service uri
             var serviceUri = info.ServiceUri.ToString().Contains("sharing/rest") ? info.ServiceUri : new Uri(_arcGISOnlineURL);
 
             // AuthenticationManager will handle challenging the user for credentials

--- a/src/DataCollection.UWP/LocalizedStrings/Resources.resw
+++ b/src/DataCollection.UWP/LocalizedStrings/Resources.resw
@@ -144,8 +144,8 @@
   <data name="InvalidInput_Title" xml:space="preserve">
     <value>Invalid input detected</value>
   </data>
-  <data name="LoginUnsuccessful_Title" xml:space="preserve">
-    <value>Login unsuccessful</value>
+  <data name="SignInUnsuccessful_Title" xml:space="preserve">
+    <value>Sign in unsuccessful</value>
   </data>
   <data name="OperationCancelled" xml:space="preserve">
     <value>The operation was canceled.</value>
@@ -249,11 +249,11 @@
   <data name="EditRecord_Tooltip" xml:space="preserve">
     <value>Edit Record</value>
   </data>
-  <data name="LogInButton.Label" xml:space="preserve">
-    <value>Log In</value>
+  <data name="SignInButton.Label" xml:space="preserve">
+    <value>Sign In</value>
   </data>
-  <data name="LogOutButton.Label" xml:space="preserve">
-    <value>Log Out</value>
+  <data name="SignOutButton.Label" xml:space="preserve">
+    <value>Sign Out</value>
   </data>
   <data name="MoreTools_Tooltip" xml:space="preserve">
     <value>More Tools</value>
@@ -318,11 +318,11 @@
   <data name="CancelSyncButton.Content" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="LoggedInTextBlock.Text" xml:space="preserve">
-    <value>You are logged in as</value>
+  <data name="SignedInTextBlock.Text" xml:space="preserve">
+    <value>You are signed in as</value>
   </data>
-  <data name="NoLogin_DeviceOffline_Message" xml:space="preserve">
-    <value>Your device must be connected to a network to login.</value>
+  <data name="NoSignIn_DeviceOffline_Message" xml:space="preserve">
+    <value>Your device must be connected to a network to sign in.</value>
   </data>
   <data name="NoOnlineMode_DeviceOffline_Message" xml:space="preserve">
     <value>Your device must be connected to a network to work online.</value>

--- a/src/DataCollection.UWP/MainPage.xaml
+++ b/src/DataCollection.UWP/MainPage.xaml
@@ -80,7 +80,7 @@
                 </interactivity:Interaction.Behaviors>
             </AppBarButton>
             <CommandBar.SecondaryCommands>
-                <!--  Inactive button displaying logged in user info  -->
+                <!--  Inactive button displaying signed in user info  -->
                 <AppBarButton DataContext="{x:Bind AuthViewModel}" Visibility="{x:Bind AuthViewModel.AuthenticatedUser, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}}">
                     <AppBarButton.Template>
                         <ControlTemplate>
@@ -91,7 +91,7 @@
                                     Source="{Binding AuthenticatedUser.ThumbnailUri, Mode=OneWay}" />
                                 <StackPanel VerticalAlignment="Center" Orientation="Vertical">
                                     <TextBlock
-                                        x:Uid="LoggedInTextBlock"
+                                        x:Uid="SignedInTextBlock"
                                         Margin="0,0,10,0"
                                         Style="{StaticResource CaptionTextBlockStyle}" />
                                     <TextBlock Text="{Binding AuthenticatedUser.FullName, Mode=OneWay}" />
@@ -187,20 +187,20 @@
 
                 <AppBarSeparator />
 
-                <!--  Log in button  -->
+                <!--  Sign in button  -->
                 <AppBarButton
-                    x:Uid="LogInButton"
-                    Command="{x:Bind AuthViewModel.LoginCommand}"
+                    x:Uid="SignInButton"
+                    Command="{x:Bind AuthViewModel.SignInCommand}"
                     Visibility="{x:Bind AuthViewModel.AuthenticatedUser, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverse}">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE77B;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
 
-                <!--  Log out button  -->
+                <!--  Sign out button  -->
                 <AppBarButton
-                    x:Uid="LogOutButton"
-                    Command="{x:Bind AuthViewModel.LogOutCommand}"
+                    x:Uid="SignOutButton"
+                    Command="{x:Bind AuthViewModel.SignOutCommand}"
                     Visibility="{x:Bind AuthViewModel.AuthenticatedUser, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}}">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE8F8;" />

--- a/src/DataCollection.WPF/DataCollection.WPF.csproj
+++ b/src/DataCollection.WPF/DataCollection.WPF.csproj
@@ -76,7 +76,7 @@
     <Compile Include="Converters\ConvertValueToCodedValueDomainValue.cs" />
     <Compile Include="Converters\MapTitleConverter.cs" />
     <Compile Include="Helpers\BrowseHelper.cs" />
-    <Compile Include="ViewModels\LoginWindowViewModel.cs" />
+    <Compile Include="ViewModels\SignInWindowViewModel.cs" />
     <Compile Include="Views\AddFeatureView.xaml.cs">
       <DependentUpon>AddFeatureView.xaml</DependentUpon>
     </Compile>
@@ -95,8 +95,8 @@
     <Compile Include="Views\IdentifiedFeaturePopup.xaml.cs">
       <DependentUpon>IdentifiedFeaturePopup.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Views\LoginWindow.xaml.cs">
-      <DependentUpon>LoginWindow.xaml</DependentUpon>
+    <Compile Include="Views\SignInWindow.xaml.cs">
+      <DependentUpon>SignInWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\OriginRelatedRecordPopup.xaml.cs">
       <DependentUpon>OriginRelatedRecordPopup.xaml</DependentUpon>
@@ -141,7 +141,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="Views\LoginWindow.xaml">
+    <Page Include="Views\SignInWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/DataCollection.WPF/MainWindow.xaml
+++ b/src/DataCollection.WPF/MainWindow.xaml
@@ -277,8 +277,8 @@
                     Margin="0,0,10,0"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Center"
-                    Command="{Binding LoginCommand}"
-                    Content="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=LogInButton.Label}"
+                    Command="{Binding SignInCommand}"
+                    Content="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=SignInButton.Label}"
                     FontSize="25"
                     Style="{StaticResource MenuButtonStyle}"
                     Visibility="{Binding AuthenticatedUser, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverse}" />
@@ -287,7 +287,7 @@
                 <Button
                     Margin="0,0,10,0"
                     HorizontalAlignment="Center"
-                    Command="{Binding LogOutCommand}"
+                    Command="{Binding SignOutCommand}"
                     FontSize="25"
                     Style="{StaticResource MenuButtonStyle}"
                     Visibility="{Binding AuthenticatedUser, Converter={StaticResource NullToVisibilityConverter}}">
@@ -297,7 +297,7 @@
                             Padding="5"
                             VerticalAlignment="Center"
                             FontSize="25"
-                            Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=LogOutButton.Label}" />
+                            Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=SignOutButton.Label}" />
                         <TextBlock
                             Padding="15,0,15,5"
                             VerticalAlignment="Center"
@@ -623,8 +623,8 @@
             </Grid>
         </Grid>
 
-        <!--  Login Window  -->
-        <views:LoginWindow
+        <!--  Sign In Window  -->
+        <views:SignInWindow
             Grid.Row="0"
             Grid.RowSpan="3"
             Grid.Column="0"

--- a/src/DataCollection.WPF/ViewModels/SignInWindowViewModel.cs
+++ b/src/DataCollection.WPF/ViewModels/SignInWindowViewModel.cs
@@ -24,7 +24,7 @@ using System.Windows.Input;
 
 namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.WPF.ViewModels
 {
-    public class LoginWindowViewModel : BaseViewModel, IOAuthAuthorizeHandler
+    public class SignInWindowViewModel : BaseViewModel, IOAuthAuthorizeHandler
     {
         // Use a TaskCompletionSource to track the completion of the authorization
         private TaskCompletionSource<IDictionary<string, string>> _tcs;

--- a/src/DataCollection.WPF/Views/SignInWindow.xaml
+++ b/src/DataCollection.WPF/Views/SignInWindow.xaml
@@ -1,5 +1,5 @@
 ﻿<UserControl
-    x:Class="Esri.ArcGISRuntime.ExampleApps.DataCollection.WPF.Views.LoginWindow"
+    x:Class="Esri.ArcGISRuntime.ExampleApps.DataCollection.WPF.Views.SignInWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="clr-namespace:Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Converters"
@@ -13,19 +13,19 @@
     mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
-            <wpfViewModels:LoginWindowViewModel x:Key="LoginWindowViewModel" />
+            <wpfViewModels:SignInWindowViewModel x:Key="SignInWindowViewModel" />
             <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
 
     <Grid
         x:Name="MainGrid"
-        DataContext="{StaticResource LoginWindowViewModel}"
+        DataContext="{StaticResource SignInWindowViewModel}"
         Visibility="{Binding WebAddress, Converter={StaticResource NullToVisibilityConverter}}">
         <Rectangle Fill="Black" Opacity=".5" />
         <WebBrowser x:Name="WebBrowser">
             <utils:WebBrowserExtensions.SourceController>
-                <utils:SourceController UriSource="{Binding WebAddress, Mode=TwoWay, Source={StaticResource LoginWindowViewModel}}" />
+                <utils:SourceController UriSource="{Binding WebAddress, Mode=TwoWay, Source={StaticResource SignInWindowViewModel}}" />
             </utils:WebBrowserExtensions.SourceController>
             <i:Interaction.Triggers>
                 <i:EventTrigger EventName="Navigating">

--- a/src/DataCollection.WPF/Views/SignInWindow.xaml.cs
+++ b/src/DataCollection.WPF/Views/SignInWindow.xaml.cs
@@ -25,16 +25,16 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.WPF.Views
     /// <summary>
     /// Interaction logic for LoginWindow.xaml
     /// </summary>
-    public partial class LoginWindow : UserControl
+    public partial class SignInWindow : UserControl
     {
         private const int ProportionalityConstant = 48000; // constant of inverse proportionality between dpi and browser height
         private const double WidthHeightRatio = 1.4; // calculated ideal ratio of width to height
-        public LoginWindow()
+        public SignInWindow()
         {
             InitializeComponent();
 
             // set the AuthorizeHandler for the authentication manager
-            AuthenticationManager.Current.OAuthAuthorizeHandler = Resources["LoginWindowViewModel"] as LoginWindowViewModel;
+            AuthenticationManager.Current.OAuthAuthorizeHandler = Resources["SignInWindowViewModel"] as SignInWindowViewModel;
             
             // Calculate and set browser size based on dpi
             SetBrowserSize();
@@ -42,7 +42,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.WPF.Views
 
         /// <summary>
         /// Method to calculate the browser size based on the screen dpi
-        /// This ensures that the login screen always displays in the correct proportions
+        /// This ensures that the sign in screen always displays in the correct proportions
         /// </summary>
         private void SetBrowserSize()
         {


### PR DESCRIPTION
This PR updates the language used in the app - should be 'Sign in' everywhere.