### PR TITLE
Allow sign in to be canceled on WPF

### DIFF
--- a/src/DataCollection.Shared/ViewModels/AuthViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/AuthViewModel.cs
@@ -146,6 +146,11 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                         {
                             var portal = await ArcGISPortal.CreateAsync(new Uri(_arcGISOnlineURL), true);
                         }
+                        catch (TaskCanceledException)
+                        {
+                            // Ignore, not really an error
+                            // The user chose to not proceed with sign in
+                        }
                         catch (Exception ex)
                         {
                             // if the token has expired, delete it and leave the user signed out

--- a/src/DataCollection.WPF/ViewModels/SignInWindowViewModel.cs
+++ b/src/DataCollection.WPF/ViewModels/SignInWindowViewModel.cs
@@ -51,6 +51,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.WPF.ViewModels
         }
 
         private ICommand _navigateCommand;
+        private ICommand _cancelCommand;
 
         /// <summary>
         /// Gets the command fired when the browser navigates
@@ -84,17 +85,31 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.WPF.ViewModels
                                 var authResponse = DecodeParameters(uri);
 
                                 // Set the result for the task completion source
-                                _tcs.SetResult(authResponse);
+                                _tcs.TrySetResult(authResponse);
                             }
                             catch (Exception ex)
                             {
-                                _tcs.SetException(ex);
+                                _tcs.TrySetException(ex);
                             }
 
                             // remove the web address
                             WebAddress = null;
                         }
                     }));
+            }
+        }
+
+        public ICommand CancelCommand
+        {
+            get
+            {
+                return _cancelCommand ?? (_cancelCommand = new DelegateCommand(
+                           (x) =>
+                           {
+                               _tcs.TrySetCanceled();
+                               // Setting web address to null will hide the sign in window.
+                               WebAddress = null;
+                           }));
             }
         }
 

--- a/src/DataCollection.WPF/Views/SignInWindow.xaml
+++ b/src/DataCollection.WPF/Views/SignInWindow.xaml
@@ -22,8 +22,21 @@
         x:Name="MainGrid"
         DataContext="{StaticResource SignInWindowViewModel}"
         Visibility="{Binding WebAddress, Converter={StaticResource NullToVisibilityConverter}}">
-        <Rectangle Fill="Black" Opacity=".5" />
-        <WebBrowser x:Name="WebBrowser">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Rectangle Fill="Black" Opacity=".5"
+                   Grid.Row="0" Grid.RowSpan="3" 
+                   Grid.Column="0" Grid.ColumnSpan="3"/>
+        <WebBrowser x:Name="WebBrowser"
+                    Grid.Row="1" Grid.Column="1">
             <utils:WebBrowserExtensions.SourceController>
                 <utils:SourceController UriSource="{Binding WebAddress, Mode=TwoWay, Source={StaticResource SignInWindowViewModel}}" />
             </utils:WebBrowserExtensions.SourceController>
@@ -33,5 +46,9 @@
                 </i:EventTrigger>
             </i:Interaction.Triggers>
         </WebBrowser>
+        <Button Content="Cancel"
+                Grid.Row="2" Grid.Column="1"
+                HorizontalAlignment="Center" VerticalAlignment="Top"
+                Margin="5" Padding="5" Command="{Binding CancelCommand}" />
     </Grid>
 </UserControl>

--- a/src/DataCollection.WPF/Views/SignInWindow.xaml
+++ b/src/DataCollection.WPF/Views/SignInWindow.xaml
@@ -15,6 +15,7 @@
         <ResourceDictionary>
             <wpfViewModels:SignInWindowViewModel x:Key="SignInWindowViewModel" />
             <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+            <converters:LocalizationConverter x:Key="LocalizationConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -46,7 +47,7 @@
                 </i:EventTrigger>
             </i:Interaction.Triggers>
         </WebBrowser>
-        <Button Content="Cancel"
+        <Button Content="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=GenericNegativeButton_Content}"
                 Grid.Row="2" Grid.Column="1"
                 HorizontalAlignment="Center" VerticalAlignment="Top"
                 Margin="5" Padding="5" Command="{Binding CancelCommand}" />


### PR DESCRIPTION
This resolves https://github.com/Esri/data-collection-dotnet/issues/1. It also resolves #29.

![2019-06-10_17-02-56](https://user-images.githubusercontent.com/29742178/59234450-a2de8b80-8ba1-11e9-8813-365d0fdb2337.gif)

Note that this affects the behavior of the UWP implementation: there is no longer an error message displayed when canceling sign in on UWP.