### PR TITLE
Remove map title binding workaround

### DIFF
--- a/src/DataCollection.Shared/ViewModels/MapViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/MapViewModel.cs
@@ -151,24 +151,6 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
             }
         }
 
-        private string _applicationTitle;
-
-        /// <summary>
-        /// Gets or sets the title of the application
-        /// </summary>
-        public string ApplicationTitle
-        {
-            get { return _applicationTitle; }
-            set
-            {
-                if (_applicationTitle != value && value != null)
-                {
-                    _applicationTitle = value;
-                    OnPropertyChanged();
-                }
-            }
-        }
-
         /// <summary>
         /// Perform feature selection 
         /// </summary>
@@ -223,7 +205,6 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
             {
                 // HACK: set app title to the title of the map
                 // This is a workaround for bug in Runtime: OnPropertyChanged isn't called when Map properties change
-                ApplicationTitle = Map.Item.Title;
 
                 // try starting location services
                 try

--- a/src/DataCollection.WPF/MainWindow.xaml
+++ b/src/DataCollection.WPF/MainWindow.xaml
@@ -157,22 +157,14 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <!--  Application Title coming from the title of the webmap  -->
-            <TextBlock
+            <TextBlock Text="{Binding MapViewModel.Map.Item.Title}"
                 Grid.Column="0"
                 Margin="15,0,0,0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 FontSize="25"
                 FontWeight="DemiBold"
-                Foreground="White">
-                <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource MapTitleConverter}">
-                        <Binding Path="MapViewModel.Map.Item.Title" />
-                        <Binding Path="MapViewModel.ApplicationTitle" />
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
+                Foreground="White" />
             <!--  TODO: Replace buttons text with icons if app is used on Windows versions < 10  -->
             <StackPanel Grid.Column="1" Orientation="Horizontal">
                 <!--  Current Location Button  -->


### PR DESCRIPTION
Removes a workaround for an issue that no longer exists in Runtime as of 100.5. 

Resolves https://github.com/Esri/data-collection-dotnet/issues/16