### PR TITLE
Fixes several issues with the attachments experience

### DIFF
--- a/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
@@ -24,6 +24,7 @@ using Esri.ArcGISRuntime.Mapping.Popups;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -184,7 +185,15 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                                 }
 #if WPF
                                 // in WPF, let Windows open the file with the application the user has set as default
-                                System.Diagnostics.Process.Start(attachmentLocalPath);
+                                try
+                                {
+                                    Process.Start(attachmentLocalPath);
+                                }
+                                catch (System.ComponentModel.Win32Exception e)
+                                {
+                                    // This happens when the user cancels opening (e.g. the user got a security prompt and chose to cancel instead of opening).
+                                    UserPromptMessenger.Instance.RaiseMessageValueChanged(null, e.Message, true, e.StackTrace);
+                                }
 #elif NETFX_CORE
                                 try
                                 {

--- a/src/DataCollection.UWP/Views/AttachmentsView.xaml
+++ b/src/DataCollection.UWP/Views/AttachmentsView.xaml
@@ -15,48 +15,60 @@
     </UserControl.Resources>
 
     <Grid>
-        <ScrollViewer VerticalScrollBarVisibility="Auto" VerticalScrollMode="Auto">
-            <!--  Wrap panel containing attachment thumbnails and names  -->
-            <ItemsControl x:Name="AttachmentsItemsControl"
-                          ItemsSource="{Binding AttachmentsViewModel.Attachments, Mode=OneWay}">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Button
-                                Grid.Column="0"
-                                Width="50"
-                                Height="50"
-                                Margin="10"
-                                Padding="0"
-                                Command="{Binding ElementName=AttachmentsItemsControl, Path=DataContext.AttachmentsViewModel.OpenAttachmentCommand, Mode=OneWay}"
-                                CommandParameter="{Binding Attachment, Mode=OneWay}">
-                                <Button.Content>
-                                    <Image Source="{Binding Thumbnail, Mode=OneWay}" />
-                                </Button.Content>
-                            </Button>
-                            <TextBlock
-                                Grid.Column="1"
-                                Padding="5"
-                                VerticalAlignment="Center"
-                                Text="{Binding Attachment.Name, Mode=OneWay}"
-                                TextWrapping="Wrap" />
-                            <Button
-                                Grid.Column="2"
-                                HorizontalAlignment="Right"
-                                Command="{Binding ElementName=AttachmentsItemsControl, Mode=OneWay, Path=DataContext.AttachmentsViewModel.DeleteAttachmentCommand}"
-                                CommandParameter="{Binding Attachment}"
-                                Content="&#xE74D;"
-                                FontFamily="Segoe MDL2 Assets"
-                                Visibility="{Binding ElementName=AttachmentsItemsControl, Mode=OneWay, Path=DataContext.EditViewModel, Converter={StaticResource NullToVisibilityConverter}}" />
-                        </Grid>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </ScrollViewer>
+        <!--  Wrap panel containing attachment thumbnails and names  -->
+        <ListView x:Name="AttachmentsItemsControl"
+                      ItemsSource="{Binding AttachmentsViewModel.Attachments, Mode=OneWay}"
+                      SelectionMode="None">
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    <Setter Property="Padding" Value="0,0,5,0" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate>
+                                <ContentPresenter />
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </ListView.ItemContainerStyle>
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <Grid HorizontalAlignment="Stretch">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Button
+                            Grid.Column="0"
+                            Width="50"
+                            Height="50"
+                            Margin="0,5,5,5"
+                            Padding="0"
+                            Command="{Binding ElementName=AttachmentsItemsControl, Path=DataContext.AttachmentsViewModel.OpenAttachmentCommand, Mode=OneWay}"
+                            CommandParameter="{Binding Attachment, Mode=OneWay}">
+                            <Button.Content>
+                                <Image Source="{Binding Thumbnail, Mode=OneWay}" />
+                            </Button.Content>
+                        </Button>
+                        <TextBlock
+                            Grid.Column="1"
+                            Padding="5"
+                            VerticalAlignment="Center"
+                            Text="{Binding Attachment.Name, Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                        <Button
+                            Grid.Column="2"
+                            HorizontalAlignment="Right"
+                            Command="{Binding ElementName=AttachmentsItemsControl, Mode=OneWay, Path=DataContext.AttachmentsViewModel.DeleteAttachmentCommand}"
+                            CommandParameter="{Binding Attachment}"
+                            Content="&#xE74D;"
+                            FontFamily="Segoe MDL2 Assets"
+                            Visibility="{Binding ElementName=AttachmentsItemsControl, Mode=OneWay, Path=DataContext.EditViewModel, Converter={StaticResource NullToVisibilityConverter}}" />
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
     </Grid>
 </UserControl>

--- a/src/DataCollection.UWP/Views/AttachmentsView.xaml
+++ b/src/DataCollection.UWP/Views/AttachmentsView.xaml
@@ -18,7 +18,7 @@
         <ScrollViewer VerticalScrollBarVisibility="Auto" VerticalScrollMode="Auto">
             <!--  Wrap panel containing attachment thumbnails and names  -->
             <ItemsControl x:Name="AttachmentsItemsControl"
-                          ItemsSource="{x:Bind AttachmentsViewModel.Attachments, Mode=OneWay}">
+                          ItemsSource="{Binding AttachmentsViewModel.Attachments, Mode=OneWay}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <Grid>

--- a/src/DataCollection.UWP/Views/AttachmentsView.xaml
+++ b/src/DataCollection.UWP/Views/AttachmentsView.xaml
@@ -15,46 +15,48 @@
     </UserControl.Resources>
 
     <Grid>
-        <!--  Wrap panel containing attachment thumbnails and names  -->
-        <ItemsControl x:Name="AttachmentsItemsControl" ItemsSource="{x:Bind AttachmentsViewModel.Attachments, Mode=OneWay}">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Button
-                            Grid.Column="0"
-                            Width="50"
-                            Height="50"
-                            Margin="10"
-                            Padding="0"
-                            Command="{Binding ElementName=AttachmentsItemsControl, Path=DataContext.AttachmentsViewModel.OpenAttachmentCommand, Mode=OneWay}"
-                            CommandParameter="{Binding Attachment, Mode=OneWay}">
-                            <Button.Content>
-                                <Image Source="{Binding Thumbnail, Mode=OneWay}" />
-                            </Button.Content>
-                        </Button>
-                        <TextBlock
-                            Grid.Column="1"
-                            Width="150"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            Text="{Binding Attachment.Name, Mode=OneWay}"
-                            TextWrapping="Wrap" />
-                        <Button
-                            Grid.Column="2"
-                            HorizontalAlignment="Right"
-                            Command="{Binding ElementName=AttachmentsItemsControl, Mode=OneWay, Path=DataContext.AttachmentsViewModel.DeleteAttachmentCommand}"
-                            CommandParameter="{Binding Attachment}"
-                            Content="&#xE74D;"
-                            FontFamily="Segoe MDL2 Assets"
-                            Visibility="{Binding ElementName=AttachmentsItemsControl, Mode=OneWay, Path=DataContext.EditViewModel, Converter={StaticResource NullToVisibilityConverter}}" />
-                    </Grid>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
+        <ScrollViewer VerticalScrollBarVisibility="Auto" VerticalScrollMode="Auto">
+            <!--  Wrap panel containing attachment thumbnails and names  -->
+            <ItemsControl x:Name="AttachmentsItemsControl"
+                          ItemsSource="{x:Bind AttachmentsViewModel.Attachments, Mode=OneWay}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Button
+                                Grid.Column="0"
+                                Width="50"
+                                Height="50"
+                                Margin="10"
+                                Padding="0"
+                                Command="{Binding ElementName=AttachmentsItemsControl, Path=DataContext.AttachmentsViewModel.OpenAttachmentCommand, Mode=OneWay}"
+                                CommandParameter="{Binding Attachment, Mode=OneWay}">
+                                <Button.Content>
+                                    <Image Source="{Binding Thumbnail, Mode=OneWay}" />
+                                </Button.Content>
+                            </Button>
+                            <TextBlock
+                                Grid.Column="1"
+                                Padding="5"
+                                VerticalAlignment="Center"
+                                Text="{Binding Attachment.Name, Mode=OneWay}"
+                                TextWrapping="Wrap" />
+                            <Button
+                                Grid.Column="2"
+                                HorizontalAlignment="Right"
+                                Command="{Binding ElementName=AttachmentsItemsControl, Mode=OneWay, Path=DataContext.AttachmentsViewModel.DeleteAttachmentCommand}"
+                                CommandParameter="{Binding Attachment}"
+                                Content="&#xE74D;"
+                                FontFamily="Segoe MDL2 Assets"
+                                Visibility="{Binding ElementName=AttachmentsItemsControl, Mode=OneWay, Path=DataContext.EditViewModel, Converter={StaticResource NullToVisibilityConverter}}" />
+                        </Grid>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/src/DataCollection.WPF/Views/AttachmentsView.xaml
+++ b/src/DataCollection.WPF/Views/AttachmentsView.xaml
@@ -17,23 +17,31 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
-        <ScrollViewer CanContentScroll="True"
-                      HorizontalScrollBarVisibility="Disabled"
-                      PanningMode="VerticalOnly"
-                      VerticalScrollBarVisibility="Auto">
-            <!--  Wrap panel containing attachment thumbnails and names  -->
-            <ItemsControl Background="White" 
-                          Margin="0,0,10,0"
-                          ItemsSource="{Binding AttachmentsViewModel.Attachments}">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Button
+        <!--  Wrap panel containing attachment thumbnails and names  -->
+        <ListView Background="White"
+                  Padding="0,0,10,0"
+                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                  ItemsSource="{Binding AttachmentsViewModel.Attachments}">
+            <ListView.ItemContainerStyle>
+                <Style TargetType="{x:Type ListViewItem}">
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type ListViewItem}">
+                                <ContentPresenter />
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </ListView.ItemContainerStyle>
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Button
                             Grid.Column="0"
                             Width="50"
                             Height="50"
@@ -41,17 +49,17 @@
                             Command="{Binding DataContext.AttachmentsViewModel.OpenAttachmentCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                             CommandParameter="{Binding Attachment}"
                             ToolTip="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=OpenAttachment_Tooltip}">
-                                <Button.Content>
-                                    <Image Source="{Binding Thumbnail}" />
-                                </Button.Content>
-                            </Button>
-                            <TextBlock
+                            <Button.Content>
+                                <Image Source="{Binding Thumbnail}" />
+                            </Button.Content>
+                        </Button>
+                        <TextBlock
                             Grid.Column="1"
                             Padding="5"
                             VerticalAlignment="Center"
                             Text="{Binding Attachment.Name}"
                             TextWrapping="Wrap" />
-                            <Button
+                        <Button
                             Grid.Column="2"
                             Width="30"
                             Height="30"
@@ -64,10 +72,9 @@
                             Style="{StaticResource MenuButtonStyle}"
                             ToolTip="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=DeleteAttachment_Tooltip}"
                             Visibility="{Binding DataContext.EditViewModel, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource NullToVisibilityConverter}}" />
-                        </Grid>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </ScrollViewer>
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
     </Grid>
 </UserControl>

--- a/src/DataCollection.WPF/Views/AttachmentsView.xaml
+++ b/src/DataCollection.WPF/Views/AttachmentsView.xaml
@@ -17,17 +17,23 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
-        <!--  Wrap panel containing attachment thumbnails and names  -->
-        <ItemsControl Background="White" ItemsSource="{Binding AttachmentsViewModel.Attachments}">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Button
+        <ScrollViewer CanContentScroll="True"
+                      HorizontalScrollBarVisibility="Disabled"
+                      PanningMode="VerticalOnly"
+                      VerticalScrollBarVisibility="Auto">
+            <!--  Wrap panel containing attachment thumbnails and names  -->
+            <ItemsControl Background="White" 
+                          Margin="0,0,10,0"
+                          ItemsSource="{Binding AttachmentsViewModel.Attachments}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Button
                             Grid.Column="0"
                             Width="50"
                             Height="50"
@@ -35,18 +41,17 @@
                             Command="{Binding DataContext.AttachmentsViewModel.OpenAttachmentCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                             CommandParameter="{Binding Attachment}"
                             ToolTip="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=OpenAttachment_Tooltip}">
-                            <Button.Content>
-                                <Image Source="{Binding Thumbnail}" />
-                            </Button.Content>
-                        </Button>
-                        <TextBlock
+                                <Button.Content>
+                                    <Image Source="{Binding Thumbnail}" />
+                                </Button.Content>
+                            </Button>
+                            <TextBlock
                             Grid.Column="1"
-                            Width="150"
                             Padding="5"
                             VerticalAlignment="Center"
                             Text="{Binding Attachment.Name}"
                             TextWrapping="Wrap" />
-                        <Button
+                            <Button
                             Grid.Column="2"
                             Width="30"
                             Height="30"
@@ -59,9 +64,10 @@
                             Style="{StaticResource MenuButtonStyle}"
                             ToolTip="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=DeleteAttachment_Tooltip}"
                             Visibility="{Binding DataContext.EditViewModel, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource NullToVisibilityConverter}}" />
-                    </Grid>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
+                        </Grid>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
     </Grid>
 </UserControl>


### PR DESCRIPTION
This PR:

* Adds vertical scroll bars to the attachments view for UWP and WPF
* Fixes an issue where attachments view wasn't working for related records on UWP
* Fixes an issue where canceling file open would crash WPF; this happens when Windows shows a security prompt and the user cancels

This resolves #18 and it resolves #44 