### PR TITLE
Make field display prominence more consistent

### DIFF
--- a/src/DataCollection.UWP/Views/DestinationRelatedRecordPopup.xaml
+++ b/src/DataCollection.UWP/Views/DestinationRelatedRecordPopup.xaml
@@ -16,11 +16,11 @@
                     <StackPanel>
                         <TextBlock
                             Margin="10,5,0,0"
-                            Style="{StaticResource BodyTextBlockStyle}"
+                            Style="{StaticResource BaseTextBlockStyle}"
                             Text="{Binding Field.Label, Mode=OneWay}" />
                         <TextBlock
                             Margin="12,5,0,5"
-                            Style="{StaticResource BaseTextBlockStyle}"
+                            Style="{StaticResource BodyTextBlockStyle}"
                             Text="{Binding FormattedValue, Mode=OneWay}" />
                     </StackPanel>
                 </DataTemplate>

--- a/src/DataCollection.UWP/Views/FeatureEditorView.xaml
+++ b/src/DataCollection.UWP/Views/FeatureEditorView.xaml
@@ -22,7 +22,7 @@
                 <!--  Data templates for all the field types used in editing features  -->
                 <DataTemplate x:Key="StringTemplate" x:Name="StringTemplate">
                     <StackPanel>
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding PopupFieldValue.Field.Label, Mode=OneWay}" />
+                        <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{Binding PopupFieldValue.Field.Label, Mode=OneWay}" />
                         <TextBox
                             AcceptsReturn="True"
                             Text="{Binding PopupFieldValue.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -36,7 +36,7 @@
                 </DataTemplate>
                 <DataTemplate x:Key="DateTemplate" x:Name="DateTemplate">
                     <StackPanel>
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding PopupFieldValue.Field.Label, Mode=OneWay}" />
+                        <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{Binding PopupFieldValue.Field.Label, Mode=OneWay}" />
                         <CalendarDatePicker
                             HorizontalAlignment="Stretch"
                             Date="{Binding PopupFieldValue.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ObjectToDateTimeOffsetConverter}}"
@@ -51,7 +51,7 @@
                 </DataTemplate>
                 <DataTemplate x:Key="NumberTemplate" x:Name="NumberTemplate">
                     <StackPanel>
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding PopupFieldValue.Field.Label, Mode=OneWay}" />
+                        <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{Binding PopupFieldValue.Field.Label, Mode=OneWay}" />
                         <TextBox InputScope="Digits" Text="{Binding PopupFieldValue.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         <TextBlock
                             Foreground="Red"
@@ -62,7 +62,7 @@
                 </DataTemplate>
                 <DataTemplate x:Key="RangeDomainTemplate" x:Name="RangeDomainTemplate">
                     <StackPanel>
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding PopupFieldValue.Field.Label, Mode=OneWay}" />
+                        <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{Binding PopupFieldValue.Field.Label, Mode=OneWay}" />
                         <TextBox InputScope="Digits" Text="{Binding PopupFieldValue.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         <TextBlock
                             Foreground="Red"
@@ -73,7 +73,7 @@
                 </DataTemplate>
                 <DataTemplate x:Key="CodedValueDomainTemplate" x:Name="CodedValueDomainTemplate">
                     <StackPanel>
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding PopupFieldValue.Field.Label, Mode=OneWay}" />
+                        <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{Binding PopupFieldValue.Field.Label, Mode=OneWay}" />
                         <ComboBox
                             HorizontalAlignment="Stretch"
                             DisplayMemberPath="Name"

--- a/src/DataCollection.UWP/Views/IdentifiedFeaturePopup.xaml
+++ b/src/DataCollection.UWP/Views/IdentifiedFeaturePopup.xaml
@@ -43,11 +43,10 @@
                                 <DataTemplate>
                                     <StackPanel>
                                         <TextBlock
-                                            Margin="10,5,10,0"
                                             Style="{StaticResource BaseTextBlockStyle}"
                                             Text="{Binding Field.Label, Mode=OneWay}" />
                                         <TextBlock
-                                            Margin="12,5,10,5"
+                                            Margin="5"
                                             Style="{StaticResource BodyTextBlockStyle}"
                                             Text="{Binding FormattedValue, Mode=OneWay}"
                                             TextWrapping="Wrap" />

--- a/src/DataCollection.UWP/Views/OriginRelatedRecordPopup.xaml
+++ b/src/DataCollection.UWP/Views/OriginRelatedRecordPopup.xaml
@@ -34,12 +34,11 @@
                             <DataTemplate>
                                 <StackPanel>
                                     <TextBlock
-                                        Margin="10,5,0,0"
-                                        Style="{StaticResource BodyTextBlockStyle}"
+                                        Style="{StaticResource BaseTextBlockStyle}"
                                         Text="{Binding Field.Label, Mode=OneWay}" />
                                     <TextBlock
-                                        Margin="12,5,0,5"
-                                        Style="{StaticResource BaseTextBlockStyle}"
+                                        Margin="5"
+                                        Style="{StaticResource BodyTextBlockStyle}"
                                         Text="{Binding FormattedValue, Mode=OneWay}"
                                         TextWrapping="Wrap" />
                                 </StackPanel>


### PR DESCRIPTION
Resolves #41

This PR makes the appearance of fields more consistent across edit and view modes and between various panes.

![2019-06-11_13-27-57](https://user-images.githubusercontent.com/29742178/59304272-beeb3700-8c4c-11e9-9037-a9bbd955b81d.gif)
