### PR TITLE
Attachment validation

### DIFF
--- a/src/DataCollection.Shared/LocalizedStrings/Resources.Designer.cs
+++ b/src/DataCollection.Shared/LocalizedStrings/Resources.Designer.cs
@@ -439,6 +439,15 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.LocalizedStrings.
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to That attachment can&apos;t be added because the file type is unsupported..
+        /// </summary>
+        internal static string InvalidAttachmentExtension_Message {
+            get {
+                return ResourceManager.GetString("InvalidAttachmentExtension_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Changes to this record are invalid. Please correct and retry saving..
         /// </summary>
         internal static string InvalidInput_Message {

--- a/src/DataCollection.Shared/LocalizedStrings/Resources.Designer.cs
+++ b/src/DataCollection.Shared/LocalizedStrings/Resources.Designer.cs
@@ -106,6 +106,24 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.LocalizedStrings.
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The attachment name has been truncated to 40 characters..
+        /// </summary>
+        internal static string AttachmentRenamedForLength_Message {
+            get {
+                return ResourceManager.GetString("AttachmentRenamedForLength_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Attachment name too long.
+        /// </summary>
+        internal static string AttachmentRenamedForLength_Title {
+            get {
+                return ResourceManager.GetString("AttachmentRenamedForLength_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Authentication error.
         /// </summary>
         internal static string AuthError_Title {

--- a/src/DataCollection.Shared/LocalizedStrings/Resources.resx
+++ b/src/DataCollection.Shared/LocalizedStrings/Resources.resx
@@ -327,4 +327,7 @@
   <data name="NoOnlineMode_DeviceOffline_Message" xml:space="preserve">
     <value>Your device must be connected to a network to work online.</value>
   </data>
+  <data name="InvalidAttachmentExtension_Message" xml:space="preserve">
+    <value>That attachment can't be added because the file type is unsupported.</value>
+  </data>
 </root>

--- a/src/DataCollection.Shared/LocalizedStrings/Resources.resx
+++ b/src/DataCollection.Shared/LocalizedStrings/Resources.resx
@@ -327,6 +327,12 @@
   <data name="NoOnlineMode_DeviceOffline_Message" xml:space="preserve">
     <value>Your device must be connected to a network to work online.</value>
   </data>
+  <data name="AttachmentRenamedForLength_Message" xml:space="preserve">
+    <value>The attachment name has been truncated to 40 characters.</value>
+  </data>
+  <data name="AttachmentRenamedForLength_Title" xml:space="preserve">
+    <value>Attachment name too long</value>
+  </data>
   <data name="InvalidAttachmentExtension_Message" xml:space="preserve">
     <value>That attachment can't be added because the file type is unsupported.</value>
   </data>

--- a/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
@@ -300,6 +300,15 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
             // determine type based on extension
             var contentType = FileExtensionHelper.GetTypeFromExtension(extension);
 
+            if (String.IsNullOrEmpty(extension) || !FileExtensionHelper.AllowedExtensions.ContainsKey(extension))
+            {
+                UserPromptMessenger.Instance.RaiseMessageValueChanged(
+                    Resources.GetString("GenericError_Title"),
+                    Resources.GetString("InvalidAttachmentExtension_Message"),
+                    true);
+                return;
+            }
+
             // add new attachment to layer
             var newAttachment = AttachmentManager.AddAttachment(filePath, contentType);
 

--- a/src/DataCollection.UWP/Helpers/MediaHelper.cs
+++ b/src/DataCollection.UWP/Helpers/MediaHelper.cs
@@ -50,7 +50,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.UWP.Helpers
             await fnd.ShowAsync();
 
             // rename file
-            await storageFile.RenameAsync(fnd.FileName + storageFile.FileType);
+            await storageFile.RenameAsync(fnd.FileName + storageFile.FileType, NameCollisionOption.ReplaceExisting);
             return storageFile;
         }
 

--- a/src/DataCollection.UWP/LocalizedStrings/Resources.resw
+++ b/src/DataCollection.UWP/LocalizedStrings/Resources.resw
@@ -327,4 +327,7 @@
   <data name="NoOnlineMode_DeviceOffline_Message" xml:space="preserve">
     <value>Your device must be connected to a network to work online.</value>
   </data>
+  <data name="InvalidAttachmentExtension_Message" xml:space="preserve">
+    <value>That attachment can't be added because the file type is unsupported.</value>
+  </data>
 </root>

--- a/src/DataCollection.UWP/LocalizedStrings/Resources.resw
+++ b/src/DataCollection.UWP/LocalizedStrings/Resources.resw
@@ -327,6 +327,12 @@
   <data name="NoOnlineMode_DeviceOffline_Message" xml:space="preserve">
     <value>Your device must be connected to a network to work online.</value>
   </data>
+  <data name="AttachmentRenamedForLength_Message" xml:space="preserve">
+    <value>The attachment name has been truncated to 40 characters.</value>
+  </data>
+  <data name="AttachmentRenamedForLength_Title" xml:space="preserve">
+    <value>Attachment name too long</value>
+  </data>
   <data name="InvalidAttachmentExtension_Message" xml:space="preserve">
     <value>That attachment can't be added because the file type is unsupported.</value>
   </data>

--- a/src/DataCollection.UWP/Views/FileNameDialog.xaml.cs
+++ b/src/DataCollection.UWP/Views/FileNameDialog.xaml.cs
@@ -42,6 +42,11 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.UWP.Views
             {
                 IsPrimaryButtonEnabled = true;
                 ValidationTextBlock.Text = "";
+
+                if (FileNameTextBox.Text.Length > 40)
+                {
+                    ValidationTextBlock.Text = "File names longer than 40 characters will be truncated";
+                }
             }
             else
             {


### PR DESCRIPTION
Two enhancements:
* Ensure that attachments have a valid file extension before committing. Resolves #17 and #23.
* Truncate filenames > 40 characters in length before uploading. Resolves #26