### PR TITLE
Improves colors for emphasis & light/dark themes

### DIFF
--- a/src/DataCollection.UWP/Converters/TitleBarConnectivityModeToColorConverter.cs
+++ b/src/DataCollection.UWP/Converters/TitleBarConnectivityModeToColorConverter.cs
@@ -26,7 +26,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.UWP.Converters
     /// <summary>
     /// Converts ConnectivityMode to color to be used for the app banner
     /// </summary>
-    class ConnectivityModeToColorConverter : IValueConverter
+    class TitleBarConnectivityModeToColorConverter : IValueConverter
     {
         /// <summary>
         /// Handle the conversion from a boolean value to a color value
@@ -35,11 +35,18 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.UWP.Converters
         {
             if (value is ConnectivityMode)
             {
-                
-                //if value is ConnectivityMode.Offline, color = gray
-                return ((ConnectivityMode)value == ConnectivityMode.Offline) ?
-                    (SolidColorBrush)Application.Current.Resources["TitleBarColorOffline"] :
-                    (SolidColorBrush)Application.Current.Resources["TitleBarColorOnline"];
+                if (parameter is string inverse && inverse == "Inverse")
+                {
+                    return ((ConnectivityMode)value == ConnectivityMode.Offline) ?
+                        (SolidColorBrush)Application.Current.Resources["TitleBarForegroundOffline"] :
+                        (SolidColorBrush)Application.Current.Resources["TitleBarForegroundOnline"];
+                } 
+                else
+                {
+                    return ((ConnectivityMode)value == ConnectivityMode.Offline) ?
+                        (SolidColorBrush)Application.Current.Resources["TitleBarBackgroundOffline"] :
+                        (SolidColorBrush)Application.Current.Resources["TitleBarBackgroundOnline"];
+                }                
             }
             else
                 return null;
@@ -53,7 +60,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.UWP.Converters
             if (value is Color)
             {
                 //if color is gray return ConnectivityMode.Offline
-                return ((Color)value == ((SolidColorBrush)Application.Current.Resources["TitleBarColorOffline"]).Color) 
+                return ((Color)value == ((SolidColorBrush)Application.Current.Resources["TitleBarBackgroundOffline"]).Color) 
                     ? ConnectivityMode.Offline : 
                     ConnectivityMode.Online;
             }

--- a/src/DataCollection.UWP/DataCollection.UWP.csproj
+++ b/src/DataCollection.UWP/DataCollection.UWP.csproj
@@ -117,7 +117,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Converters\ConnectivityModeToColorConverter.cs" />
+    <Compile Include="Converters\TitleBarConnectivityModeToColorConverter.cs" />
     <Compile Include="Converters\ObjectToDateTimeOffsetConverter.cs" />
     <Compile Include="Helpers\MediaHelper.cs" />
     <Compile Include="MainPage.xaml.cs">

--- a/src/DataCollection.UWP/MainPage.xaml
+++ b/src/DataCollection.UWP/MainPage.xaml
@@ -20,7 +20,7 @@
             <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
             <converters:NullToBoolConverter x:Key="NullToBoolConverter" />
             <converters:ConnectivityModeToVisibilityConverter x:Key="ConnectivityModeToVisibilityConverter" />
-            <localConverters:ConnectivityModeToColorConverter x:Key="ConnectivityModeToColorConverter" />
+            <localConverters:TitleBarConnectivityModeToColorConverter x:Key="ConnectivityModeToColorConverter" />
             <ControlTemplate x:Key="BladeItemTemplate" TargetType="controls:BladeItem">
                 <!-- Template modified from source found at https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/e29e20ae3726dc68ea97921bb3762042301b9760/Microsoft.Toolkit.Uwp.UI.Controls/BladeView/BladeView.xaml -->
                 <Grid BorderBrush="{TemplateBinding BorderBrush}"
@@ -104,7 +104,8 @@
         <CommandBar
             Grid.Row="0"
             Grid.ColumnSpan="3"
-            Background="{x:Bind MainViewModel.ConnectivityMode, Mode=OneWay, Converter={StaticResource ConnectivityModeToColorConverter}}">
+            Background="{x:Bind MainViewModel.ConnectivityMode, Mode=OneWay, Converter={StaticResource ConnectivityModeToColorConverter}}"
+            Foreground="{x:Bind MainViewModel.ConnectivityMode, Mode=OneWay, Converter={StaticResource ConnectivityModeToColorConverter}, ConverterParameter=Inverse}">
             <CommandBar.Content>
                 <TextBlock
                     Margin="15,0,0,0"
@@ -114,7 +115,8 @@
             <AppBarButton
                 x:Uid="CurrentLocationButton"
                 Command="{x:Bind MainViewModel.MapViewModel.MoveToCurrentLocationCommand, Mode=OneWay}"
-                IsEnabled="{x:Bind MainViewModel.MapViewModel.IsLocationStarted, Mode=OneWay}">
+                IsEnabled="{x:Bind MainViewModel.MapViewModel.IsLocationStarted, Mode=OneWay}"
+                Foreground="{x:Bind MainViewModel.ConnectivityMode, Mode=OneWay, Converter={StaticResource ConnectivityModeToColorConverter}, ConverterParameter=Inverse}">
                 <AppBarButton.Icon>
                     <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE81D;" />
                 </AppBarButton.Icon>
@@ -122,6 +124,7 @@
             <AppBarButton
                 x:Uid="AddFeatureButton"
                 Icon="Add"
+                Foreground="{x:Bind MainViewModel.ConnectivityMode, Mode=OneWay, Converter={StaticResource ConnectivityModeToColorConverter}, ConverterParameter=Inverse}"
                 IsEnabled="{Binding ElementName=MapView, Path=Map, Mode=OneWay, Converter={StaticResource NullToBoolConverter}}"
                 Visibility="{x:Bind MainViewModel.IsLocationOnlyMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Inverse}">
                 <interactivity:Interaction.Behaviors>

--- a/src/DataCollection.UWP/ResourceDictionary.xaml
+++ b/src/DataCollection.UWP/ResourceDictionary.xaml
@@ -3,17 +3,19 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Dark">
-            <SolidColorBrush x:Key="TitleBarColorOnline" Color="Green" />
-            <SolidColorBrush x:Key="TitleBarColorOffline" Color="{ThemeResource SystemChromeMediumLowColor}" />
-            <Color x:Key="SystemListLowColor">DarkOrange</Color>
+            <SolidColorBrush x:Key="TitleBarBackgroundOnline" Color="Green" />
+            <SolidColorBrush x:Key="TitleBarBackgroundOffline" Color="{ThemeResource SystemChromeMediumLowColor}" />
+            <SolidColorBrush x:Key="TitleBarForegroundOnline" Color="White" />
+            <SolidColorBrush x:Key="TitleBarForegroundOffline" Color="{ThemeResource SystemBaseHighColor}" />
             <Color x:Key="SystemAccentColor">Green</Color>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <SolidColorBrush x:Key="TitleBarColorOnline" Color="Green" />
-            <SolidColorBrush x:Key="TitleBarColorOffline" Color="{ThemeResource SystemChromeMediumLowColor}" />
-            <Color x:Key="SystemListLowColor">DarkOrange</Color>
+            <SolidColorBrush x:Key="TitleBarBackgroundOnline" Color="Green" />
+            <SolidColorBrush x:Key="TitleBarBackgroundOffline" Color="{ThemeResource SystemChromeMediumLowColor}" />
             <Color x:Key="SystemAccentColor">Green</Color>
             <SolidColorBrush x:Key="AccentButtonForeground" Color="{ThemeResource SystemChromeBlackHighColor}" />
+            <SolidColorBrush x:Key="TitleBarForegroundOnline" Color="White" />
+            <SolidColorBrush x:Key="TitleBarForegroundOffline" Color="{ThemeResource SystemBaseHighColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
     <Thickness x:Key="FieldMargin">0,5,0,5</Thickness>


### PR DESCRIPTION
Completes #57 by removing the orange hover emphasis color. Also updates the title bar color to be more consistent with the choices made for WPF (e.g. white on green).