### PR TITLE
Improve identify & attachment experiences

### DIFF
--- a/src/DataCollection.Shared/Binding Support/IdentifyController.cs
+++ b/src/DataCollection.Shared/Binding Support/IdentifyController.cs
@@ -24,7 +24,9 @@ using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 #if NETFX_CORE
 using Windows.UI.Xaml;
@@ -34,17 +36,24 @@ using System.Windows;
 
 namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Utils
 {
-    public sealed class IdentifyController
+    public sealed class IdentifyController : INotifyPropertyChanged
     {
         private WeakReference<MapView> _mapViewWeakRef;
         private bool _isIdentifyInProgress;
         private bool _wasMapViewDoubleTapped;
+        private CancellationTokenSource _canellationTokenSource = new CancellationTokenSource();
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IdentifyController"/> class.
-        /// </summary>
-        public IdentifyController()
+        public bool IsIdentifyInProgress
         {
+            get => _isIdentifyInProgress;
+            set
+            {
+                if (_isIdentifyInProgress != value)
+                {
+                    _isIdentifyInProgress = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsIdentifyInProgress)));
+                }
+            }
         }
 
         /// <summary>
@@ -108,79 +117,97 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Utils
         /// </summary>
         private async void MapView_Tapped(object sender, GeoViewInputEventArgs e)
         {
-            _isIdentifyInProgress = true;
-            var mapView = (MapView)sender;
-            var target = Target;
-
             try
             {
                 // Wait for double tap to fire
                 // Identify is only peformed on single tap. The delay is used to detect and ignore double taps
-                await Task.Delay(500);
+                await Task.Delay(300);
 
                 // If view has been double tapped, set tapped to handled and flag back to false
                 // If view has been tapped just once, perform identify
-                if (_wasMapViewDoubleTapped == true)
+                if (_wasMapViewDoubleTapped)
                 {
                     e.Handled = true;
                     _wasMapViewDoubleTapped = false;
+                    return;
                 }
-                else
+
+                if (IsIdentifyInProgress)
                 {
-                    if (target is ILoadable loadable && loadable.LoadStatus == LoadStatus.NotLoaded)
-                    {
-                        await loadable.LoadAsync();
-                    }
-
-                    // get the tap location in screen units and geographic coordinates
-                    var tapScreenPoint = e.Position;
-                    _tappedLocation = e.Location;
-
-                    // set identify parameters
-                    var pixelTolerance = 10;
-                    var returnPopupsOnly = false;
-                    var maxResultCount = 5;
-
-                    IReadOnlyList<IdentifyLayerResult> layerResults = null;
-                    IReadOnlyList<IdentifyGraphicsOverlayResult> graphicsOverlayResults = null;
-                    if (target == null)
-                    {
-                        // An identify target is not specified, so identify all layers and overlays
-                        var identifyLayersTask = mapView.IdentifyLayersAsync(tapScreenPoint, pixelTolerance, returnPopupsOnly, maxResultCount);
-                        var identifyOverlaysTask = mapView.IdentifyGraphicsOverlaysAsync(tapScreenPoint, pixelTolerance, returnPopupsOnly, maxResultCount);
-                        await Task.WhenAll(identifyLayersTask, identifyOverlaysTask);
-                        layerResults = identifyLayersTask.Result;
-                        graphicsOverlayResults = identifyOverlaysTask.Result;
-                    }
-                    else if (target is Layer targetLayer && mapView.Map.OperationalLayers.Contains(target as Layer))
-                    {
-                        // identify features in the target layer, passing the tap point, tolerance, types to return, and max results
-                        var identifyResult = await mapView.IdentifyLayerAsync(targetLayer, tapScreenPoint, pixelTolerance, returnPopupsOnly, maxResultCount);
-                        layerResults = new List<IdentifyLayerResult> { identifyResult }.AsReadOnly();
-                    }
-                    else if (target is GraphicsOverlay targetOverlay && mapView.GraphicsOverlays.Contains(target as GraphicsOverlay))
-                    {
-                        // identify features in the target layer, passing the tap point, tolerance, types to return, and max results
-                        var identifyResult = await mapView.IdentifyGraphicsOverlayAsync(targetOverlay, tapScreenPoint, pixelTolerance, returnPopupsOnly, maxResultCount);
-                        graphicsOverlayResults = new List<IdentifyGraphicsOverlayResult> { identifyResult }.AsReadOnly();
-                    }
-                    else if (target is ArcGISSublayer sublayer)
-                    {
-                        var layer = mapView?.Map?.AllLayers?.OfType<ArcGISMapImageLayer>()?.Where(l => l.Sublayers.Contains(sublayer))?.FirstOrDefault();
-
-                        if (layer != null)
-                        {
-
-                            // identify features in the target layer, passing the tap point, tolerance, types to return, and max results
-                            var topLevelIdentifyResult = await mapView.IdentifyLayerAsync(layer, tapScreenPoint, pixelTolerance, returnPopupsOnly, maxResultCount);
-                            var sublayerIdentifyResult = topLevelIdentifyResult?.SublayerResults?.Where(r => r.LayerContent.Equals(sublayer)).FirstOrDefault();
-
-                            layerResults = new List<IdentifyLayerResult> { sublayerIdentifyResult }.AsReadOnly();
-                        }
-                    }
-
-                    OnIdentifyCompleted(layerResults, graphicsOverlayResults);
+                    _canellationTokenSource.Cancel();
+                    _canellationTokenSource = new CancellationTokenSource();
                 }
+
+                IsIdentifyInProgress = true;
+                var mapView = (MapView)sender;
+                var target = Target;
+
+
+                if (target is ILoadable loadable && loadable.LoadStatus == LoadStatus.NotLoaded)
+                {
+                    await loadable.LoadAsync();
+                }
+
+                // get the tap location in screen units and geographic coordinates
+                var tapScreenPoint = e.Position;
+                _tappedLocation = e.Location;
+
+                // set identify parameters
+                var pixelTolerance = 10;
+                var returnPopupsOnly = false;
+                var maxResultCount = 5;
+
+                IReadOnlyList<IdentifyLayerResult> layerResults = null;
+                IReadOnlyList<IdentifyGraphicsOverlayResult> graphicsOverlayResults = null;
+                CancellationTokenSource _currentSource = _canellationTokenSource;
+                if (target == null)
+                {
+                    // An identify target is not specified, so identify all layers and overlays
+                    var identifyLayersTask = mapView.IdentifyLayersAsync(tapScreenPoint, pixelTolerance, returnPopupsOnly, maxResultCount, _currentSource.Token);
+                    var identifyOverlaysTask = mapView.IdentifyGraphicsOverlaysAsync(tapScreenPoint, pixelTolerance, returnPopupsOnly, maxResultCount);
+                    await Task.WhenAll(identifyLayersTask, identifyOverlaysTask);
+                    if (_currentSource.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                    layerResults = identifyLayersTask.Result;
+                    graphicsOverlayResults = identifyOverlaysTask.Result;
+                }
+                else if (target is Layer targetLayer && mapView.Map.OperationalLayers.Contains(target as Layer))
+                {
+                    // identify features in the target layer, passing the tap point, tolerance, types to return, and max results
+                    var identifyResult = await mapView.IdentifyLayerAsync(targetLayer, tapScreenPoint, pixelTolerance, returnPopupsOnly, maxResultCount, _currentSource.Token);
+                    layerResults = new List<IdentifyLayerResult> { identifyResult }.AsReadOnly();
+                }
+                else if (target is GraphicsOverlay targetOverlay && mapView.GraphicsOverlays.Contains(target as GraphicsOverlay))
+                {
+                    // identify features in the target layer, passing the tap point, tolerance, types to return, and max results
+                    var identifyResult = await mapView.IdentifyGraphicsOverlayAsync(targetOverlay, tapScreenPoint, pixelTolerance, returnPopupsOnly, maxResultCount);
+                    if (_currentSource.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                    graphicsOverlayResults = new List<IdentifyGraphicsOverlayResult> { identifyResult }.AsReadOnly();
+                }
+                else if (target is ArcGISSublayer sublayer)
+                {
+                    var layer = mapView?.Map?.AllLayers?.OfType<ArcGISMapImageLayer>()?.Where(l => l.Sublayers.Contains(sublayer))?.FirstOrDefault();
+
+                    if (layer != null)
+                    {
+
+                        // identify features in the target layer, passing the tap point, tolerance, types to return, and max results
+                        var topLevelIdentifyResult = await mapView.IdentifyLayerAsync(layer, tapScreenPoint, pixelTolerance, returnPopupsOnly, maxResultCount, _currentSource.Token);
+                        var sublayerIdentifyResult = topLevelIdentifyResult?.SublayerResults?.Where(r => r.LayerContent.Equals(sublayer)).FirstOrDefault();
+
+                        layerResults = new List<IdentifyLayerResult> { sublayerIdentifyResult }.AsReadOnly();
+                    }
+                }
+                OnIdentifyCompleted(layerResults, graphicsOverlayResults);
+            }
+            catch (TaskCanceledException)
+            {
+                // Ignore, not really an error.
             }
             catch (Exception ex)
             {
@@ -189,9 +216,11 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Utils
                     ex.Message,
                     true,
                     ex.StackTrace);
+            } 
+            finally
+            {
+                IsIdentifyInProgress = false;
             }
-
-            _isIdentifyInProgress = false;
         }
 
         /// <summary>
@@ -223,6 +252,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Utils
         }
 
         public event EventHandler<IdentifyEventArgs> IdentifyCompleted;
+        public event PropertyChangedEventHandler PropertyChanged;
 
         private void OnIdentifyCompleted(IReadOnlyList<IdentifyLayerResult> layerResults,
             IReadOnlyList<IdentifyGraphicsOverlayResult> graphicsOverlayResults)

--- a/src/DataCollection.Shared/Binding Support/IdentifyController.cs
+++ b/src/DataCollection.Shared/Binding Support/IdentifyController.cs
@@ -43,19 +43,6 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Utils
         private bool _wasMapViewDoubleTapped;
         private CancellationTokenSource _canellationTokenSource = new CancellationTokenSource();
 
-        public bool IsIdentifyInProgress
-        {
-            get => _isIdentifyInProgress;
-            set
-            {
-                if (_isIdentifyInProgress != value)
-                {
-                    _isIdentifyInProgress = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsIdentifyInProgress)));
-                }
-            }
-        }
-
         /// <summary>
         /// Gets or sets the MapView on which to perform identify operations
         /// </summary>
@@ -258,6 +245,22 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Utils
             IReadOnlyList<IdentifyGraphicsOverlayResult> graphicsOverlayResults)
         {
             IdentifyCompleted?.Invoke(this, new IdentifyEventArgs(layerResults, graphicsOverlayResults));
+        }
+
+        /// <summary>
+        /// Property so that identify work in progress can be shown in the UI.
+        /// </summary>
+        public bool IsIdentifyInProgress
+        {
+            get => _isIdentifyInProgress;
+            set
+            {
+                if (_isIdentifyInProgress != value)
+                {
+                    _isIdentifyInProgress = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsIdentifyInProgress)));
+                }
+            }
         }
     }
 }

--- a/src/DataCollection.Shared/Converters/BytesToHumanReadableSizeConverter.cs
+++ b/src/DataCollection.Shared/Converters/BytesToHumanReadableSizeConverter.cs
@@ -1,0 +1,53 @@
+﻿/*******************************************************************************
+  * Copyright 2019 Esri
+  *
+  *  Licensed under the Apache License, Version 2.0 (the "License");
+  *  you may not use this file except in compliance with the License.
+  *  You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  *   Unless required by applicable law or agreed to in writing, software
+  *   distributed under the License is distributed on an "AS IS" BASIS,
+  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *   See the License for the specific language governing permissions and
+  *   limitations under the License.
+******************************************************************************/
+
+using System;
+using System.Globalization;
+using Humanizer;
+#if NETFX_CORE
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using CustomCultureInfo = System.String;
+#else
+using System.Windows.Data;
+using System.Windows;
+using CustomCultureInfo = System.Globalization.CultureInfo;
+#endif
+
+
+namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Converters
+{
+
+    /// <summary>
+    /// Converts int to visibility
+    /// </summary>
+    class BytesToHumanReadableSizeConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CustomCultureInfo culture)
+        {
+            if (value is Int64 byteCount)
+            {
+                return byteCount.Bytes().Humanize("#.#");
+            }
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CustomCultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/DataCollection.Shared/Converters/EmptyCollectionToVisibilityConverter.cs
+++ b/src/DataCollection.Shared/Converters/EmptyCollectionToVisibilityConverter.cs
@@ -1,0 +1,63 @@
+﻿/*******************************************************************************
+  * Copyright 2019 Esri
+  *
+  *  Licensed under the Apache License, Version 2.0 (the "License");
+  *  you may not use this file except in compliance with the License.
+  *  You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  *   Unless required by applicable law or agreed to in writing, software
+  *   distributed under the License is distributed on an "AS IS" BASIS,
+  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *   See the License for the specific language governing permissions and
+  *   limitations under the License.
+******************************************************************************/
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+#if NETFX_CORE
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using CustomCultureInfo = System.String;
+#else
+using System.Windows.Data;
+using System.Windows;
+using CustomCultureInfo = System.Globalization.CultureInfo;
+#endif
+
+namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Converters
+{
+    /// <summary>
+    /// Converts boolean to visibility
+    /// </summary>
+    class EmptyCollectionToVisibilityConverter : IValueConverter
+    {
+        /// <summary>
+        /// Convert from a collection size to a visibility; used to either show a list view or a placeholder message e.g. "No attachments found"
+        /// </summary>
+        object IValueConverter.Convert(object value, Type targetType, object parameter, CustomCultureInfo culture)
+        {
+            if (value is IEnumerable<object> collection)
+            {
+                // Handle bool(true) to visibility and bool(false) (inverse) to visibility
+                if (parameter != null && parameter.ToString() == "Inverse")
+                {
+                    return collection.Any() ? Visibility.Visible : Visibility.Collapsed;
+                }
+                else
+                {
+                    return collection.Any() ? Visibility.Collapsed : Visibility.Visible;
+                }
+            }
+            else
+                return Visibility.Collapsed;
+        }
+
+        object IValueConverter.ConvertBack(object value, Type targetType, object parameter, CustomCultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/DataCollection.Shared/DataCollection.Shared.projitems
+++ b/src/DataCollection.Shared/DataCollection.Shared.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Converters\BoolToVisibilityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\LocalizationConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\NullToBoolConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Converters\BytesToHumanReadableSizeConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ProgressToVisibilityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\FeatureExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\FeatureTableExtensions.cs" />

--- a/src/DataCollection.Shared/DataCollection.Shared.projitems
+++ b/src/DataCollection.Shared/DataCollection.Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Binding Support\LocationDisplayController.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Binding Support\IdentifyController.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Binding Support\ViewpointController.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Converters\EmptyCollectionToVisibilityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ConnectivityModeToVisibilityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\BoolToVisibilityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\LocalizationConverter.cs" />

--- a/src/DataCollection.Shared/Models/StagedAttachment.cs
+++ b/src/DataCollection.Shared/Models/StagedAttachment.cs
@@ -65,21 +65,8 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Models
             {
                 // create thumbnail for the image attachments
                 case PopupAttachmentType.Image:
-                    try
-                    {
-                        var rtImage = await attachment.CreateThumbnailAsync(50, 50);
-                        Thumbnail = await rtImage.ToImageSourceAsync();
-                    }
-                    catch (Exception ex)
-                    {
-                        // API currently does not support generating thumbnails for GIFs 
-                        if (ex.Message == "Conversion failed exception: Unsupported image file format.")
-                            Thumbnail = new BitmapImage(new Uri("pack://application:,,,/Images/AttachmentImage.png"));
-                        else
-                            UserPromptMessenger.Instance.RaiseMessageValueChanged(null, ex.Message, true, ex.StackTrace);
-                    }
+                    Thumbnail = new BitmapImage(new Uri("pack://application:,,,/Images/AttachmentImage.png"));
                     break;
-
                 // use placeholder images for the rest of the attachments
                 case PopupAttachmentType.Video:
                     Thumbnail = new BitmapImage(new Uri("pack://application:,,,/Images/AttachmentVideo.png"));
@@ -100,25 +87,9 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Models
                 // create thumbnail for the image attachments
                 // must do this on UI thread due to bindings 
                 case PopupAttachmentType.Image:
-                    await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.High, async () =>
+                    await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.High, () =>
                     {
-                        try
-                        {
-                            var rtImage = await attachment.CreateThumbnailAsync(50, 50);
-                            Thumbnail = await rtImage.ToImageSourceAsync();
-                        }
-                        catch (Exception ex)
-                        {
-                            // API currently does not support generating thumbnails for GIFs 
-                            if (ex.Message == "Conversion failed exception: Unsupported image file format.")
-                            {
-                                Thumbnail = new BitmapImage(new Uri("ms-appx:///Assets/AttachmentImage.png"));
-                            }
-                            else
-                            {
-                                UserPromptMessenger.Instance.RaiseMessageValueChanged(null, ex.Message, true, ex.StackTrace);
-                            }
-                        }
+                        Thumbnail = new BitmapImage(new Uri("ms-appx:///Assets/AttachmentImage.png"));
                     });
                     break;
 

--- a/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
@@ -146,63 +146,65 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                     async (x) =>
                     {
                         IsLoadingAttachments = true;
-                        if (x != null && x is PopupAttachment attachment)
+                        try
                         {
-                            if (attachment.LoadStatus != LoadStatus.Loaded)
+                            if (x != null && x is PopupAttachment attachment)
                             {
-                                await attachment.LoadAsync();
-                            }
-
-                            if (attachment.Filename == null)
-                            {
-                                UserPromptMessenger.Instance.RaiseMessageValueChanged(
-                                    Resources.GetString("FileNotFound_Title"),
-                                    Resources.GetString("FileNotFound_Message"),
-                                    true);
-                                return;
-                            }
-                            // HACK: This workflow is in place until API changes occur to save the attachment with its proper name and extension
-                            // when an attachment is downloaded, the API generates a random temp file name that cannot be opened unless renamed to have a proper extension
-                            // when an attachment is newly added, the API points to the file the user selected, so the name and extension are valid and the file can be opened directly
-                            var fileInfo = new FileInfo(attachment.Filename);
-                            var attachmentLocalPath = "";
-
-                            // if attachment was just added, its path still points to the location on disk, so open from there
-                            // otherwise, use dowload path 
-                            if (fileInfo.Exists)
-                            {
-                                if (fileInfo.Name == attachment.Name)
+                                if (attachment.LoadStatus != LoadStatus.Loaded)
                                 {
-                                    attachmentLocalPath = attachment.Filename;
+                                    await attachment.LoadAsync();
                                 }
-                                else
+
+                                if (attachment.Filename == null)
                                 {
-                                    // create temp directory from the random attachment file name 
-                                    var directory = Path.Combine(fileInfo.DirectoryName, fileInfo.Name.Replace(".", ""));
-
-                                    if (!Directory.Exists(directory))
-                                    {
-                                        Directory.CreateDirectory(directory);
-                                    }
-
-                                    // place file into the newly created temp directory
-                                    attachmentLocalPath = Path.Combine(directory, attachment.Name);
-                                    if (!File.Exists(attachmentLocalPath))
-                                    {
-                                        File.Copy(attachment.Filename, attachmentLocalPath);
-                                    }
+                                    UserPromptMessenger.Instance.RaiseMessageValueChanged(
+                                        Resources.GetString("FileNotFound_Title"),
+                                        Resources.GetString("FileNotFound_Message"),
+                                        true);
+                                    return;
                                 }
+                                // HACK: This workflow is in place until API changes occur to save the attachment with its proper name and extension
+                                // when an attachment is downloaded, the API generates a random temp file name that cannot be opened unless renamed to have a proper extension
+                                // when an attachment is newly added, the API points to the file the user selected, so the name and extension are valid and the file can be opened directly
+                                var fileInfo = new FileInfo(attachment.Filename);
+                                var attachmentLocalPath = "";
+
+                                // if attachment was just added, its path still points to the location on disk, so open from there
+                                // otherwise, use dowload path 
+                                if (fileInfo.Exists)
+                                {
+                                    if (fileInfo.Name == attachment.Name)
+                                    {
+                                        attachmentLocalPath = attachment.Filename;
+                                    }
+                                    else
+                                    {
+                                        // create temp directory from the random attachment file name 
+                                        var directory = Path.Combine(fileInfo.DirectoryName, fileInfo.Name.Replace(".", ""));
+
+                                        if (!Directory.Exists(directory))
+                                        {
+                                            Directory.CreateDirectory(directory);
+                                        }
+
+                                        // place file into the newly created temp directory
+                                        attachmentLocalPath = Path.Combine(directory, attachment.Name);
+                                        if (!File.Exists(attachmentLocalPath))
+                                        {
+                                            File.Copy(attachment.Filename, attachmentLocalPath);
+                                        }
+                                    }
 #if WPF
-                                // in WPF, let Windows open the file with the application the user has set as default
-                                try
-                                {
-                                    Process.Start(attachmentLocalPath);
-                                }
-                                catch (System.ComponentModel.Win32Exception e)
-                                {
-                                    // This happens when the user cancels opening (e.g. the user got a security prompt and chose to cancel instead of opening).
-                                    UserPromptMessenger.Instance.RaiseMessageValueChanged(null, e.Message, true, e.StackTrace);
-                                }
+                                    // in WPF, let Windows open the file with the application the user has set as default
+                                    try
+                                    {
+                                        Process.Start(attachmentLocalPath);
+                                    }
+                                    catch (System.ComponentModel.Win32Exception e)
+                                    {
+                                        // This happens when the user cancels opening (e.g. the user got a security prompt and chose to cancel instead of opening).
+                                        UserPromptMessenger.Instance.RaiseMessageValueChanged(null, e.Message, true, e.StackTrace);
+                                    }
 #elif NETFX_CORE
                                 try
                                 {
@@ -217,17 +219,25 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                                 // will throw if another platform is added without handling this 
                                 throw new NotImplementedException();
 #endif
-                            }
-                            else
-                            {
-                                UserPromptMessenger.Instance.RaiseMessageValueChanged(
-                                     Resources.GetString("FileNotFound_Title"),
-                                     Resources.GetString("FileNotFound_Message"),
-                                     true);
-                                return;
+                                }
+                                else
+                                {
+                                    UserPromptMessenger.Instance.RaiseMessageValueChanged(
+                                         Resources.GetString("FileNotFound_Title"),
+                                         Resources.GetString("FileNotFound_Message"),
+                                         true);
+                                    return;
+                                }
                             }
                         }
-                        IsLoadingAttachments = false;
+                        catch (Exception e)
+                        {
+                            UserPromptMessenger.Instance.RaiseMessageValueChanged(null, e.Message, true, e.StackTrace);
+                        }
+                        finally
+                        {
+                            IsLoadingAttachments = false;
+                        }
                     }));
             }
         }
@@ -279,40 +289,49 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
         /// </summary>
         internal async Task LoadAttachments()
         {
-            IsLoadingAttachments = true;
-            // clear any existing attachments in the collection
-            Attachments.Clear();
-
-            // create list of tasks to run in parallel
-            List<Task> tasks = new List<Task>();
-
-            if (AttachmentManager.Attachments == null)
+            try
             {
-                return;
-            }
+                IsLoadingAttachments = true;
+                // clear any existing attachments in the collection
+                Attachments.Clear();
 
-            // loop through attachments and add them to the collection
-            foreach (var attachment in AttachmentManager.Attachments)
-            {
-                var stagedAttachment = new StagedAttachment();
-                var loadTask = stagedAttachment.LoadAsync(attachment);
+                // create list of tasks to run in parallel
+                List<Task> tasks = new List<Task>();
+
+                if (AttachmentManager.Attachments == null)
+                {
+                    return;
+                }
+
+                // loop through attachments and add them to the collection
+                foreach (var attachment in AttachmentManager.Attachments)
+                {
+                    var stagedAttachment = new StagedAttachment();
+                    var loadTask = stagedAttachment.LoadAsync(attachment);
 
 
 #if WPF
-                // add attachment to collection using the UI thread (for the binding to work)
-                Application.Current.Dispatcher.Invoke(new Action(() => Attachments.Add(stagedAttachment)));
+                    // add attachment to collection using the UI thread (for the binding to work)
+                    Application.Current.Dispatcher.Invoke(new Action(() => Attachments.Add(stagedAttachment)));
 #else
                 // add attachment to collection
                 Attachments.Add(stagedAttachment);
 #endif
 
-                tasks.Add(loadTask);
+                    tasks.Add(loadTask);
+                }
+
+                // run parallel tasks
+                await Task.WhenAll(tasks);
             }
-
-            // run parallel tasks
-            await Task.WhenAll(tasks);
-
-            IsLoadingAttachments = false;
+            catch (Exception e)
+            {
+                UserPromptMessenger.Instance.RaiseMessageValueChanged(null, e.Message, true, e.StackTrace);
+            }
+            finally
+            {
+                IsLoadingAttachments = false;
+            }
         }
 
         /// <summary>

--- a/src/DataCollection.UWP/DataCollection.UWP.csproj
+++ b/src/DataCollection.UWP/DataCollection.UWP.csproj
@@ -321,6 +321,9 @@
     <PackageReference Include="Esri.ArcGISRuntime.UWP">
       <Version>100.5.0</Version>
     </PackageReference>
+    <PackageReference Include="Humanizer.Core">
+      <Version>2.7.9</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.8</Version>
     </PackageReference>

--- a/src/DataCollection.UWP/LocalizedStrings/Resources.resw
+++ b/src/DataCollection.UWP/LocalizedStrings/Resources.resw
@@ -345,4 +345,7 @@
   <data name="ExpiredSignInToken_Title" xml:space="preserve">
     <value>Login Expired</value>
   </data>
+  <data name="NoAttachmentsFound_Message" xml:space="preserve">
+    <value>No attachments found.</value>
+  </data>
 </root>

--- a/src/DataCollection.UWP/MainPage.xaml
+++ b/src/DataCollection.UWP/MainPage.xaml
@@ -86,6 +86,7 @@
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -271,6 +272,7 @@
         <esri:MapView
             x:Name="MapView"
             Grid.Row="1"
+            Grid.RowSpan="2"
             Grid.ColumnSpan="3"
             utils:MapViewExtensions.IdentifyController="{x:Bind MainViewModel.IdentifyController, Mode=OneWay}"
             DataContext="{x:Bind MainViewModel}"
@@ -283,9 +285,11 @@
             </utils:MapViewExtensions.LocationDisplayController>
         </esri:MapView>
 
+        
+
         <!--  Compass control that displays when user rotates the map  -->
         <toolkit:Compass
-            Grid.Row="1"
+            Grid.Row="2"
             Grid.Column="2"
             Margin="20"
             VerticalAlignment="Bottom"
@@ -358,6 +362,7 @@
         <!--  BladeView control that contains the popups for identified features and related records  -->
         <controls:BladeView
             Grid.Row="1"
+            Grid.RowSpan="2"
             Grid.Column="0"
             BladeClosed="BladeView_BladeClosed"
             BladeMode="Normal"
@@ -387,10 +392,18 @@
             </controls:BladeItem>
         </controls:BladeView>
 
+        <!-- Progress indicator for when identify is in progress -->
+        <ProgressBar 
+            IsIndeterminate="True" 
+            Visibility="{x:Bind MainViewModel.IdentifyController.IsIdentifyInProgress, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+            Grid.Row="1" 
+            Grid.Column="0"
+            Grid.ColumnSpan="3" />
+
         <!--  Busy Waiting View  -->
         <Grid
             Grid.Row="0"
-            Grid.RowSpan="2"
+            Grid.RowSpan="3"
             Grid.Column="0"
             Grid.ColumnSpan="3"
             Background="{ThemeResource SystemControlChromeMediumAcrylicElementMediumBrush}"

--- a/src/DataCollection.UWP/Views/AttachmentsView.xaml
+++ b/src/DataCollection.UWP/Views/AttachmentsView.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="using:Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Converters"
+    xmlns:converters2="using:Esri.ArcGISRuntime.ExampleApps.DataCollection.UWP.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     d:DesignHeight="300"
@@ -11,12 +12,22 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+            <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
 
     <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <ProgressBar
+            Grid.Row="0"
+            IsIndeterminate="True"
+            Visibility="{Binding AttachmentsViewModel.IsLoadingAttachments, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
         <!--  Wrap panel containing attachment thumbnails and names  -->
         <ListView x:Name="AttachmentsItemsControl"
+                  Grid.Row="1"
                       ItemsSource="{Binding AttachmentsViewModel.Attachments, Mode=OneWay}"
                       SelectionMode="None">
             <ListView.ItemContainerStyle>

--- a/src/DataCollection.UWP/Views/AttachmentsView.xaml
+++ b/src/DataCollection.UWP/Views/AttachmentsView.xaml
@@ -14,6 +14,7 @@
             <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
             <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
             <converters:LocalizationConverter x:Key="LocalizationConverter" />
+            <converters:EmptyCollectionToVisibilityConverter x:Key="EmptyCollectionToVisibilityConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -29,8 +30,9 @@
         <!--  Wrap panel containing attachment thumbnails and names  -->
         <ListView x:Name="AttachmentsItemsControl"
                   Grid.Row="1"
-                      ItemsSource="{Binding AttachmentsViewModel.Attachments, Mode=OneWay}"
-                      SelectionMode="None">
+                  ItemsSource="{Binding AttachmentsViewModel.Attachments, Mode=OneWay}"
+                  Visibility="{Binding AttachmentsViewModel.Attachments, Mode=OneWay, Converter={StaticResource EmptyCollectionToVisibilityConverter},ConverterParameter='Inverse'}"
+                  SelectionMode="None">
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -85,5 +87,12 @@
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
+        <TextBlock Grid.Row="0"
+                   Grid.RowSpan="2"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Text="{x:Bind Converter={StaticResource LocalizationConverter}, ConverterParameter=NoAttachmentsFound_Message}" 
+                   Style="{ThemeResource SubtitleTextBlockStyle}"
+                   Visibility="{Binding AttachmentsViewModel.Attachments, Mode=OneWay, Converter={StaticResource EmptyCollectionToVisibilityConverter}}" />
     </Grid>
 </UserControl>

--- a/src/DataCollection.UWP/Views/AttachmentsView.xaml
+++ b/src/DataCollection.UWP/Views/AttachmentsView.xaml
@@ -27,6 +27,7 @@
         <ProgressBar
             Grid.Row="0"
             IsIndeterminate="True"
+            Margin="0,0,0,10"
             Visibility="{Binding AttachmentsViewModel.IsLoadingAttachments, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
         <!--  Wrap panel containing attachment thumbnails and names  -->
         <ListView x:Name="AttachmentsItemsControl"

--- a/src/DataCollection.UWP/Views/AttachmentsView.xaml
+++ b/src/DataCollection.UWP/Views/AttachmentsView.xaml
@@ -15,6 +15,7 @@
             <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
             <converters:LocalizationConverter x:Key="LocalizationConverter" />
             <converters:EmptyCollectionToVisibilityConverter x:Key="EmptyCollectionToVisibilityConverter" />
+            <converters:BytesToHumanReadableSizeConverter x:Key="BytesToHumanReadableSizeConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -55,18 +56,30 @@
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
                         <Image 
                             Grid.Column="0"
-                            Height="25" Width="25"
-                            Source="{Binding Thumbnail, Mode=OneWay}" />
-                        
+                            Grid.Row="0" Grid.RowSpan="2"
+                            Height="40" Width="40"
+                            Source="{Binding Thumbnail, Mode=OneWay}" />                        
                         <TextBlock
                             Grid.Column="1"
+                            Grid.Row="0"
                             VerticalAlignment="Center"
                             Text="{Binding Attachment.Name, Mode=OneWay}"
-                            TextWrapping="Wrap" />
+                            FontWeight="SemiBold"
+                            TextWrapping="NoWrap" />
+                        <TextBlock 
+                            Grid.Row="1" Grid.Column="1"
+                            Text="{Binding Attachment.Size, Converter={StaticResource BytesToHumanReadableSizeConverter}}"
+                            Style="{ThemeResource BodyTextBlockStyle}"
+                            Opacity="0.6"/>
                         <Button
                             Grid.Column="2"
+                            Grid.Row="0" Grid.RowSpan="2"
                             HorizontalAlignment="Right"
                             Command="{Binding ElementName=AttachmentsItemsControl, Mode=OneWay, Path=DataContext.AttachmentsViewModel.DeleteAttachmentCommand}"
                             CommandParameter="{Binding Attachment}"
@@ -76,6 +89,7 @@
                             ToolTipService.ToolTip="{x:Bind Converter={StaticResource LocalizationConverter}, ConverterParameter=DeleteAttachment_Tooltip}"/>
                         <Button
                             Grid.Column="3"
+                            Grid.Row="0" Grid.RowSpan="2"
                             HorizontalAlignment="Right"
                             Content="&#xE8A7;"
                             FontFamily="Segoe MDL2 Assets"

--- a/src/DataCollection.UWP/Views/AttachmentsView.xaml
+++ b/src/DataCollection.UWP/Views/AttachmentsView.xaml
@@ -3,9 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="using:Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Converters"
-    xmlns:converters2="using:Esri.ArcGISRuntime.ExampleApps.DataCollection.UWP.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Models"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -13,6 +13,7 @@
         <ResourceDictionary>
             <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
             <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+            <converters:LocalizationConverter x:Key="LocalizationConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -44,28 +45,21 @@
                 </Style>
             </ListView.ItemContainerStyle>
             <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Grid HorizontalAlignment="Stretch">
+                <DataTemplate x:DataType="models:StagedAttachment">
+                    <Grid HorizontalAlignment="Stretch" ColumnSpacing="10">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <Button
+                        <Image 
                             Grid.Column="0"
-                            Width="50"
-                            Height="50"
-                            Margin="0,5,5,5"
-                            Padding="0"
-                            Command="{Binding ElementName=AttachmentsItemsControl, Path=DataContext.AttachmentsViewModel.OpenAttachmentCommand, Mode=OneWay}"
-                            CommandParameter="{Binding Attachment, Mode=OneWay}">
-                            <Button.Content>
-                                <Image Source="{Binding Thumbnail, Mode=OneWay}" />
-                            </Button.Content>
-                        </Button>
+                            Height="25" Width="25"
+                            Source="{Binding Thumbnail, Mode=OneWay}" />
+                        
                         <TextBlock
                             Grid.Column="1"
-                            Padding="5"
                             VerticalAlignment="Center"
                             Text="{Binding Attachment.Name, Mode=OneWay}"
                             TextWrapping="Wrap" />
@@ -76,7 +70,17 @@
                             CommandParameter="{Binding Attachment}"
                             Content="&#xE74D;"
                             FontFamily="Segoe MDL2 Assets"
-                            Visibility="{Binding ElementName=AttachmentsItemsControl, Mode=OneWay, Path=DataContext.EditViewModel, Converter={StaticResource NullToVisibilityConverter}}" />
+                            Visibility="{Binding ElementName=AttachmentsItemsControl, Mode=OneWay, Path=DataContext.EditViewModel, Converter={StaticResource NullToVisibilityConverter}}"
+                            ToolTipService.ToolTip="{x:Bind Converter={StaticResource LocalizationConverter}, ConverterParameter=DeleteAttachment_Tooltip}"/>
+                        <Button
+                            Grid.Column="3"
+                            HorizontalAlignment="Right"
+                            Content="&#xE8A7;"
+                            FontFamily="Segoe MDL2 Assets"
+                            Command="{Binding ElementName=AttachmentsItemsControl, Path=DataContext.AttachmentsViewModel.OpenAttachmentCommand, Mode=OneWay}"
+                            CommandParameter="{Binding Attachment, Mode=OneWay}"
+                            ToolTipService.ToolTip="{x:Bind Converter={StaticResource LocalizationConverter}, ConverterParameter=OpenAttachment_Tooltip}">
+                        </Button>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/src/DataCollection.WPF/DataCollection.WPF.csproj
+++ b/src/DataCollection.WPF/DataCollection.WPF.csproj
@@ -165,6 +165,9 @@
     <PackageReference Include="Extended.Wpf.Toolkit">
       <Version>3.5.0</Version>
     </PackageReference>
+    <PackageReference Include="Humanizer.Core">
+      <Version>2.7.9</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
       <Version>1.0.1</Version>
     </PackageReference>

--- a/src/DataCollection.WPF/LocalizedStrings/Resources.resx
+++ b/src/DataCollection.WPF/LocalizedStrings/Resources.resx
@@ -345,4 +345,7 @@
   <data name="ExpiredSignInToken_Title" xml:space="preserve">
     <value>Login Expired</value>
   </data>
+  <data name="NoAttachmentsFound_Message" xml:space="preserve">
+    <value>No attachments found.</value>
+  </data>
 </root>

--- a/src/DataCollection.WPF/MainWindow.xaml
+++ b/src/DataCollection.WPF/MainWindow.xaml
@@ -35,6 +35,7 @@
     <Grid DataContext="{StaticResource MainViewModel}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -48,6 +49,8 @@
                 MaxWidth="300" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
+
+        
 
         <!--  MapView control  -->
         <esri:MapView
@@ -66,9 +69,17 @@
             </utils:MapViewExtensions.LocationDisplayController>
         </esri:MapView>
 
+        <ProgressBar 
+            Grid.Row="1" 
+            IsIndeterminate="True"
+            Visibility="{Binding IdentifyController.IsIdentifyInProgress, Converter={StaticResource BoolToVisibilityConverter}}"
+            Height="16"
+            Grid.Column="0" 
+            Grid.ColumnSpan="3" />
+
         <!--  Compass control that displays when user rotates the map  -->
         <esri:Compass
-            Grid.Row="1"
+            Grid.Row="2"
             Grid.Column="2"
             Margin="20"
             AutoHide="True"
@@ -77,7 +88,7 @@
         <!--  New feature overlay  -->
         <views:AddFeatureView
             x:Name="AddFeatureView"
-            Grid.Row="1"
+            Grid.Row="2"
             Grid.RowSpan="2"
             Grid.Column="0"
             Grid.ColumnSpan="3"
@@ -85,7 +96,7 @@
 
         <!--  Download view  -->
         <views:DownloadView
-            Grid.Row="1"
+            Grid.Row="2"
             Grid.RowSpan="2"
             Grid.Column="0"
             Grid.ColumnSpan="3"
@@ -226,6 +237,7 @@
         <!--  Menu Panel  -->
         <Grid
             Grid.Row="1"
+            Grid.RowSpan="2"
             Grid.Column="2"
             MinWidth="100"
             MaxWidth="300"
@@ -502,6 +514,7 @@
         <!--  Popup containing identified feature information  -->
         <Grid
             Grid.Row="1"
+            Grid.RowSpan="2"
             Grid.Column="0"
             Grid.ColumnSpan="2"
             Visibility="{Binding IdentifiedFeatureViewModel, Converter={StaticResource NullToVisibilityConverter}}">
@@ -618,12 +631,12 @@
         <!--  Sign In Window  -->
         <views:SignInWindow
             Grid.Row="0"
-            Grid.RowSpan="2"
+            Grid.RowSpan="3"
             Grid.Column="0"
             Grid.ColumnSpan="3" />
 
         <Grid Grid.Row="0"
-              Grid.RowSpan="2"
+              Grid.RowSpan="3"
               Grid.Column="0"
               Grid.ColumnSpan="3"
               Visibility="{Binding IsBusyWaiting, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}">

--- a/src/DataCollection.WPF/Views/AttachmentsView.xaml
+++ b/src/DataCollection.WPF/Views/AttachmentsView.xaml
@@ -6,20 +6,33 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     d:DesignHeight="450"
-    d:DesignWidth="800"
+    d:DesignWidth="200"
     mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
             <converters:LocalizationConverter x:Key="LocalizationConverter" />
+            <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="../ResourceDictionary.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <ProgressBar
+            Grid.Row="0"
+            Visibility="{Binding AttachmentsViewModel.IsLoadingAttachments,Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+            Grid.Column="0" Grid.ColumnSpan="2"
+            Height="8"
+            IsIndeterminate="True" />
+
         <!--  Wrap panel containing attachment thumbnails and names  -->
         <ListView Background="White"
                   Padding="0,0,10,0"
+                  Grid.Row="1"
                   ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                   ItemsSource="{Binding AttachmentsViewModel.Attachments}">
             <ListView.ItemContainerStyle>
@@ -40,19 +53,13 @@
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <Button
-                            Grid.Column="0"
-                            Width="50"
-                            Height="50"
-                            Margin="10"
-                            Command="{Binding DataContext.AttachmentsViewModel.OpenAttachmentCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                            CommandParameter="{Binding Attachment}"
-                            ToolTip="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=OpenAttachment_Tooltip}">
-                            <Button.Content>
-                                <Image Source="{Binding Thumbnail}" />
-                            </Button.Content>
-                        </Button>
+                        <Image Grid.Column="0"
+                               Width="20" Height="20"
+                               Margin="10"
+                               Source="{Binding Thumbnail}"
+                               />
                         <TextBlock
                             Grid.Column="1"
                             Padding="5"
@@ -72,6 +79,20 @@
                             Style="{StaticResource MenuButtonStyle}"
                             ToolTip="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=DeleteAttachment_Tooltip}"
                             Visibility="{Binding DataContext.EditViewModel, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource NullToVisibilityConverter}}" />
+                        <Button
+                            Grid.Column="3"
+                            Command="{Binding DataContext.AttachmentsViewModel.OpenAttachmentCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                            CommandParameter="{Binding Attachment}"
+                            ToolTip="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=OpenAttachment_Tooltip}"
+                            Width="30"
+                            Height="30"
+                            Margin="10,0,0,0"
+                            HorizontalAlignment="Right"
+                            Content="&#xE8A7;"
+                            FontFamily="Segoe MDL2 Assets"
+                            FontSize="15"
+                            Style="{StaticResource MenuButtonStyle}">
+                        </Button>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/src/DataCollection.WPF/Views/AttachmentsView.xaml
+++ b/src/DataCollection.WPF/Views/AttachmentsView.xaml
@@ -12,6 +12,7 @@
         <ResourceDictionary>
             <converters:LocalizationConverter x:Key="LocalizationConverter" />
             <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+            <converters:EmptyCollectionToVisibilityConverter x:Key="EmptyCollectionToVisibilityConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="../ResourceDictionary.xaml" />
             </ResourceDictionary.MergedDictionaries>
@@ -34,7 +35,8 @@
                   Padding="0,0,10,0"
                   Grid.Row="1"
                   ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                  ItemsSource="{Binding AttachmentsViewModel.Attachments}">
+                  ItemsSource="{Binding AttachmentsViewModel.Attachments}"
+                  Visibility="{Binding AttachmentsViewModel.Attachments, Converter={StaticResource EmptyCollectionToVisibilityConverter}, ConverterParameter='Inverse'}">
             <ListView.ItemContainerStyle>
                 <Style TargetType="{x:Type ListViewItem}">
                     <Setter Property="Template">
@@ -97,5 +99,13 @@
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
+        <TextBlock Grid.Row="0"
+                   Grid.RowSpan="2"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=NoAttachmentsFound_Message}" 
+                   Visibility="{Binding AttachmentsViewModel.Attachments, Mode=OneWay, Converter={StaticResource EmptyCollectionToVisibilityConverter}}"
+                   FontWeight="SemiBold"
+                   Margin="15" />
     </Grid>
 </UserControl>

--- a/src/DataCollection.WPF/Views/AttachmentsView.xaml
+++ b/src/DataCollection.WPF/Views/AttachmentsView.xaml
@@ -13,6 +13,7 @@
             <converters:LocalizationConverter x:Key="LocalizationConverter" />
             <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
             <converters:EmptyCollectionToVisibilityConverter x:Key="EmptyCollectionToVisibilityConverter" />
+            <converters:BytesToHumanReadableSizeConverter x:Key="BytesToHumanReadableSizeConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="../ResourceDictionary.xaml" />
             </ResourceDictionary.MergedDictionaries>
@@ -50,44 +51,57 @@
             </ListView.ItemContainerStyle>
             <ListView.ItemTemplate>
                 <DataTemplate>
-                    <Grid>
+                    <Grid Margin="10">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
                         <Image Grid.Column="0"
-                               Width="20" Height="20"
-                               Margin="10"
+                               Grid.Row="0" Grid.RowSpan="2"
+                               Width="40" Height="40"
+                               Margin="0,0,10,0"
                                Source="{Binding Thumbnail}"
                                />
                         <TextBlock
                             Grid.Column="1"
-                            Padding="5"
-                            VerticalAlignment="Center"
+                            Grid.Row="0"
+                            FontWeight="SemiBold"
                             Text="{Binding Attachment.Name}"
-                            TextWrapping="Wrap" />
+                            TextWrapping="NoWrap" />
+                        <TextBlock
+                            Grid.Column="1"
+                            Grid.Row="1"
+                            Text="{Binding Attachment.Size, Converter={StaticResource BytesToHumanReadableSizeConverter}}"
+                            Opacity="0.6" />
                         <Button
                             Grid.Column="2"
-                            Width="30"
-                            Height="30"
+                            Grid.Row="0" Grid.RowSpan="2"
+                            Width="25"
+                            Height="25"
                             HorizontalAlignment="Right"
                             Command="{Binding DataContext.AttachmentsViewModel.DeleteAttachmentCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                             CommandParameter="{Binding Attachment}"
                             Content="&#xE74D;"
                             FontFamily="Segoe MDL2 Assets"
                             FontSize="15"
+                            Margin="10,0,0,0"
                             Style="{StaticResource MenuButtonStyle}"
                             ToolTip="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=DeleteAttachment_Tooltip}"
                             Visibility="{Binding DataContext.EditViewModel, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource NullToVisibilityConverter}}" />
                         <Button
                             Grid.Column="3"
+                            Grid.Row="0" Grid.RowSpan="2"
                             Command="{Binding DataContext.AttachmentsViewModel.OpenAttachmentCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                             CommandParameter="{Binding Attachment}"
                             ToolTip="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=OpenAttachment_Tooltip}"
-                            Width="30"
-                            Height="30"
+                            Width="25"
+                            Height="25"
                             Margin="10,0,0,0"
                             HorizontalAlignment="Right"
                             Content="&#xE8A7;"


### PR DESCRIPTION
Resolves open-source-apps/98. 

Enhancements:

* Reduce delay for double-taps to 300ms; 500ms felt noticeably too long and made the UI seem unresponsive.
* Cancel in-progress identify if the user attempts to identify again (identify can take a while because it hits the network)
* Show a message when there are no attachments to load, rather than just the empty view.
* Don't eagerly download attachments; only download them if the user wants to view them
* Update the attachments UI to show a button to open attachments. Use an image, rather than an image in a button, to show a thumbnail; thumbnail is now always an icon rather than an image preview for performance reasons. 
* Added `IsIdentifyInProgress` property to identify controller to enable showing an activity indicator in the UI; updated both UWP and WPF to show that activity indicator when an identify is in progress
* Added `IsLoadingAttachment` property to `AttachmentViewModel` to enable visualizing attachment load activity; it can take a while to download large attachments, so it is important to show that something is happening; update WPF and UWP to show that activity indicator while an attachment is downloading. 