### PR TITLE
Misc. fixes from pre-release review

### DIFF
--- a/src/DataCollection.Shared/Properties/Settings.cs
+++ b/src/DataCollection.Shared/Properties/Settings.cs
@@ -60,8 +60,6 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Properties
             {
                 if (_instance == null)
                 {
-                    _instance = new Settings();
-
                     // if settings file doesn't exist on disk, make a new one and save it
                     if (!File.Exists(_settingsPath))
                     {
@@ -103,31 +101,34 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Properties
         private Settings()
         {
             // fires when any of the specified settings values change
-            BroadcastMessenger.Instance.BroadcastMessengerValueChanged += (s, l) =>
-            {
-                if (l.Args.Key == BroadcastMessageKey.ConnectivityMode)
-                {
-                    _instance.ConnectivityMode = l.Args.Value?.ToString();
-                }
-                else if (l.Args.Key == BroadcastMessageKey.OAuthRefreshToken)
-                {
-                    _instance.OAuthRefreshToken = l.Args.Value?.ToString();
-                }
-                else if (l.Args.Key == BroadcastMessageKey.AuthenticatedUser)
-                {
-                    _instance.AuthenticatedUserName = ((PortalUser)l.Args.Value)?.UserName;
-                }
-                else if (l.Args.Key == BroadcastMessageKey.SyncDate)
-                {
-                    _instance.SyncDate = l.Args.Value?.ToString();
-                }
-                else if (l.Args.Key == BroadcastMessageKey.DownloadPath)
-                {
-                    _instance.CurrentOfflineSubdirectory = l.Args.Value?.ToString();
-                }
+            BroadcastMessenger.Instance.BroadcastMessengerValueChanged -= HandleSettingsChange;
+            BroadcastMessenger.Instance.BroadcastMessengerValueChanged += HandleSettingsChange;
+        }
 
-                SerializeSettings(_instance);
-            };
+        private void HandleSettingsChange(object sender, BroadcastMessengerEventArgs l)
+        {
+            if (l.Args.Key == BroadcastMessageKey.ConnectivityMode)
+            {
+                _instance.ConnectivityMode = l.Args.Value?.ToString();
+            }
+            else if (l.Args.Key == BroadcastMessageKey.OAuthRefreshToken)
+            {
+                _instance.OAuthRefreshToken = l.Args.Value?.ToString();
+            }
+            else if (l.Args.Key == BroadcastMessageKey.AuthenticatedUser)
+            {
+                _instance.AuthenticatedUserName = ((PortalUser)l.Args.Value)?.UserName;
+            }
+            else if (l.Args.Key == BroadcastMessageKey.SyncDate)
+            {
+                _instance.SyncDate = l.Args.Value?.ToString();
+            }
+            else if (l.Args.Key == BroadcastMessageKey.DownloadPath)
+            {
+                _instance.CurrentOfflineSubdirectory = l.Args.Value?.ToString();
+            }
+
+            SerializeSettings(_instance);
         }
 
         [XmlElement("ArcGISOnlineURL")]

--- a/src/DataCollection.Shared/Properties/Settings.cs
+++ b/src/DataCollection.Shared/Properties/Settings.cs
@@ -121,6 +121,10 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Properties
                 {
                     _instance.SyncDate = l.Args.Value?.ToString();
                 }
+                else if (l.Args.Key == BroadcastMessageKey.DownloadPath)
+                {
+                    _instance.CurrentOfflineSubdirectory = l.Args.Value?.ToString();
+                }
 
                 SerializeSettings(_instance);
             };

--- a/src/DataCollection.Shared/Properties/Settings.cs
+++ b/src/DataCollection.Shared/Properties/Settings.cs
@@ -188,6 +188,9 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.Properties
         [XmlElement("SyncDate")]
         public string SyncDate { get; set; }
 
+        [XmlElement("CurrentOfflineSubdirectory")]
+        public string CurrentOfflineSubdirectory { get; set; }
+
         /// <summary>
         /// Serializes Settings object and saves it to the settings file
         /// </summary>

--- a/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
@@ -69,13 +69,10 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
             get => _newAttachmentPath;
             set
             {
-                if (_newAttachmentPath != value)
+                _newAttachmentPath = value;
+                if (_newAttachmentPath != null && File.Exists(_newAttachmentPath))
                 {
-                    _newAttachmentPath = value;
-                    if (_newAttachmentPath != null && File.Exists(_newAttachmentPath))
-                    {
-                        AddNewAttachment(_newAttachmentPath);
-                    }
+                    AddNewAttachment(_newAttachmentPath);
                 }
             }
         }
@@ -309,12 +306,14 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                     // add attachment to collection using the UI thread (for the binding to work)
                     Application.Current.Dispatcher.Invoke(new Action(() => Attachments.Add(stagedAttachment)));
 #else
-                // add attachment to collection
-                Attachments.Add(stagedAttachment);
+                    // add attachment to collection
+                    Attachments.Add(stagedAttachment);
 #endif
 
                     tasks.Add(loadTask);
                 }
+
+                OnPropertyChanged(nameof(HasAttachments));
 
                 // run parallel tasks
                 await Task.WhenAll(tasks);
@@ -361,6 +360,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                 var stagedAttachment = new StagedAttachment();
                 await stagedAttachment.LoadAsync(newAttachment);
                 Attachments.Add(stagedAttachment);
+                OnPropertyChanged(nameof(HasAttachments));
             }
             catch (Exception ex)
             {
@@ -423,6 +423,9 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                 }
             }
         }
+
+        public bool HasAttachments => Attachments.Count > 0;
+
 #if NETFX_CORE
         /// <summary>
         /// Add new attachment file to the attachment manager
@@ -455,6 +458,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                 var stagedAttachment = new StagedAttachment();
                 await stagedAttachment.LoadAsync(newAttachment);
                 Attachments.Add(stagedAttachment);
+                OnPropertyChanged(nameof(HasAttachments));
             }
             catch (Exception ex)
             {

--- a/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
@@ -188,11 +188,22 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                                         bool attachmentOpened = await Launcher.LaunchFileAsync(storageFile);
 
                                         // If that fails, show the app chooser/find app in Store dialog
+                                        LauncherOptions launcherOptions = new LauncherOptions { DisplayApplicationPicker = true };
                                         if (!attachmentOpened)
                                         {
-                                            LauncherOptions launcherOptions = new LauncherOptions();
-                                            launcherOptions.DisplayApplicationPicker = true;
-                                            await Launcher.LaunchFileAsync(storageFile, launcherOptions);
+                                            attachmentOpened = await Launcher.LaunchFileAsync(storageFile, launcherOptions);
+                                        }
+
+                                        // If that fails again, try with a new extension
+                                        if (!attachmentOpened && !Path.HasExtension(attachment.Filename))
+                                        {
+                                            var newStorageFile = await storageFile.CopyAsync(ApplicationData.Current.TemporaryFolder, $"{Path.GetFileName(attachment.Filename)}.attachment", NameCollisionOption.GenerateUniqueName);
+                                            attachmentOpened = await Launcher.LaunchFileAsync(newStorageFile, launcherOptions);
+                                        }
+
+                                        if (!attachmentOpened)
+                                        {
+                                            throw new InvalidOperationException(Resources.GetString("UnsupportedAttachment_Message"));
                                         }
                                     }
                                     catch (Exception ex)

--- a/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/AttachmentsViewModel.cs
@@ -33,6 +33,7 @@ using System.Windows;
 #elif NETFX_CORE
 using Windows.Storage;
 using Windows.Storage.Streams;
+using Windows.System;
 using Windows.UI.Core;
 #endif
 
@@ -182,8 +183,17 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
     #elif NETFX_CORE
                                     try
                                     {
+                                        // Try to launch the file with the default app
                                         var storageFile = await StorageFile.GetFileFromPathAsync(attachment.Filename);
-                                        await Windows.System.Launcher.LaunchFileAsync(storageFile);
+                                        bool attachmentOpened = await Launcher.LaunchFileAsync(storageFile);
+
+                                        // If that fails, show the app chooser/find app in Store dialog
+                                        if (!attachmentOpened)
+                                        {
+                                            LauncherOptions launcherOptions = new LauncherOptions();
+                                            launcherOptions.DisplayApplicationPicker = true;
+                                            await Launcher.LaunchFileAsync(storageFile, launcherOptions);
+                                        }
                                     }
                                     catch (Exception ex)
                                     {

--- a/src/DataCollection.Shared/ViewModels/AuthViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/AuthViewModel.cs
@@ -199,7 +199,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
             // Create generate token options if necessary
             if (info.GenerateTokenOptions == null)
             {
-                info.GenerateTokenOptions = new GenerateTokenOptions();
+                info.GenerateTokenOptions = new GenerateTokenOptions { TokenValidity = -1 };
             }
 
             // if no refresh token, call to generate credentials

--- a/src/DataCollection.Shared/ViewModels/DownloadViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/DownloadViewModel.cs
@@ -39,6 +39,10 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
         {
             _map = map;
             _downloadPath = downloadPath;
+            if (!System.IO.Directory.Exists(_downloadPath))
+            {
+                System.IO.Directory.CreateDirectory(_downloadPath);
+            }
             IsAwaitingDownload = true;
         }
 

--- a/src/DataCollection.Shared/ViewModels/MainViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/MainViewModel.cs
@@ -371,7 +371,8 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
                             // Remove reference to any existing offline map
                             await ReleaseOfflineMap();
 
-                            Settings.Default.CurrentOfflineSubdirectory = Convert.ToBase64String(Guid.NewGuid().ToByteArray()).TrimEnd('=').Replace('/', '+').Replace('\\', '+');
+                            string newPath = Convert.ToBase64String(Guid.NewGuid().ToByteArray()).TrimEnd('=').Replace('/', '+').Replace('\\', '+');
+                            BroadcastMessenger.Instance.RaiseBroadcastMessengerValueChanged(newPath, BroadcastMessageKey.DownloadPath);
                             _currentOfflineSubdirectory = Settings.Default.CurrentOfflineSubdirectory;
 
                             // set up a new DownloadViewModel
@@ -911,7 +912,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.DataCollection.Shared.ViewModels
             finally
             {
                 _currentOfflineSubdirectory = null;
-                Settings.Default.CurrentOfflineSubdirectory = null;
+                BroadcastMessenger.Instance.RaiseBroadcastMessengerValueChanged(null, BroadcastMessageKey.DownloadPath);
             }
         }
     }

--- a/src/DataCollection.UWP/LocalizedStrings/Resources.resw
+++ b/src/DataCollection.UWP/LocalizedStrings/Resources.resw
@@ -348,4 +348,7 @@
   <data name="NoAttachmentsFound_Message" xml:space="preserve">
     <value>No Attachments</value>
   </data>
+  <data name="UnsupportedAttachment_Message" xml:space="preserve">
+    <value>Couldn't open that attachment because it isn't supported.</value>
+  </data>
 </root>

--- a/src/DataCollection.UWP/LocalizedStrings/Resources.resw
+++ b/src/DataCollection.UWP/LocalizedStrings/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AuthError_Title" xml:space="preserve">
-    <value>Authentication error</value>
+    <value>Authentication Error</value>
   </data>
   <data name="DiscardEditsConfirmation_Message" xml:space="preserve">
     <value>This will quit your edit sessions and will cause all of your unsaved changes to be lost.</value>
@@ -127,7 +127,7 @@
     <value>Are you sure you want to discard changes?</value>
   </data>
   <data name="ConditionDBH_UpdateError_Title" xml:space="preserve">
-    <value>Unable to update Condition &amp; DBH</value>
+    <value>Unable to Update Condition &amp; DBH</value>
   </data>
   <data name="DeleteConfirmation_Message" xml:space="preserve">
     <value>This will remove the feature from the database permanently and cannot be undone.</value>
@@ -136,16 +136,16 @@
     <value>Are you sure you want to delete this feature?</value>
   </data>
   <data name="GetFeatureRelationshipError_Message" xml:space="preserve">
-    <value>An error occured when attempting to retrieve relationships for the feature.</value>
+    <value>An error occurred when attempting to retrieve relationships for the feature.</value>
   </data>
   <data name="InvalidInput_Message" xml:space="preserve">
     <value>Changes to this record are invalid. Please correct and retry saving.</value>
   </data>
   <data name="InvalidInput_Title" xml:space="preserve">
-    <value>Invalid input detected</value>
+    <value>Invalid Input Detected</value>
   </data>
   <data name="SignInUnsuccessful_Title" xml:space="preserve">
-    <value>Sign in unsuccessful</value>
+    <value>Sign In Unsuccessful</value>
   </data>
   <data name="OperationCancelled" xml:space="preserve">
     <value>The operation was canceled.</value>
@@ -154,7 +154,7 @@
     <value>An error occured when attempting to retrieve related records for the feature.</value>
   </data>
   <data name="GenericError_Title" xml:space="preserve">
-    <value>An error has occured</value>
+    <value>An Error Occurred</value>
   </data>
   <data name="DeleteMap_Message" xml:space="preserve">
     <value>You will no longer have a map if you are in offline mode. </value>
@@ -163,13 +163,13 @@
     <value>Are you sure you want to delete the offline map?</value>
   </data>
   <data name="DownloadFailed_Title" xml:space="preserve">
-    <value>Download failed</value>
+    <value>Download Failed</value>
   </data>
   <data name="DownloadWithErrors_Title" xml:space="preserve">
-    <value>Download completed with errors</value>
+    <value>Download Completed with Errors</value>
   </data>
   <data name="IOException_Title" xml:space="preserve">
-    <value>IO exception</value>
+    <value>IO Exception</value>
   </data>
   <data name="DeleteMapWithUnsyncedChanges_Message" xml:space="preserve">
     <value>The offline map contains un-synchronized changes. You will no longer have a map when you are in offline mode and will lose your existing changes. </value>
@@ -187,7 +187,7 @@
     <value>Discard</value>
   </data>
   <data name="DeviceOffline_Title" xml:space="preserve">
-    <value>Device is offline</value>
+    <value>Device is Offline</value>
   </data>
   <data name="NoDelete_DeviceOffline_Message" xml:space="preserve">
     <value>Your device must be connected to a network to delete the offline map.</value>
@@ -202,19 +202,19 @@
     <value>The application was unable to delete the offline map and needs to restart. </value>
   </data>
   <data name="IdentifyError_Title" xml:space="preserve">
-    <value>Error while identifying feature</value>
+    <value>Error Occurred While Identifying Feature</value>
   </data>
   <data name="DeserializationError_Title" xml:space="preserve">
-    <value>Error retrieving application settings</value>
+    <value>Error Retrieving Application Settings</value>
   </data>
   <data name="SerializationError_Title" xml:space="preserve">
-    <value>Error saving application settings</value>
+    <value>Error While Saving Application Settings</value>
   </data>
   <data name="AddFeatureLabel_Line1.Text" xml:space="preserve">
-    <value>Choose the location where you would like to add a feature</value>
+    <value>Choose the location where you would like to add a feature.</value>
   </data>
   <data name="AddFeatureLabel_Line2.Text" xml:space="preserve">
-    <value>Pan and zoom map under pin</value>
+    <value>Pan and zoom map under pin.</value>
   </data>
   <data name="AddFeatureButton.Label" xml:space="preserve">
     <value>Add Feature</value>
@@ -241,10 +241,10 @@
     <value>Preparing map for offline use. Please wait.</value>
   </data>
   <data name="DownloadLabel_Line1.Text" xml:space="preserve">
-    <value>Select the region of the map to take offline</value>
+    <value>Select the region of the map to take offline.</value>
   </data>
   <data name="DownloadLabel_Line2.Text" xml:space="preserve">
-    <value>Pan and zoom map within rectangle</value>
+    <value>Pan and zoom map within the rectangle.</value>
   </data>
   <data name="EditRecord_Tooltip" xml:space="preserve">
     <value>Edit Record</value>
@@ -289,7 +289,7 @@
     <value>Center on Location</value>
   </data>
   <data name="MapLoadingError_Title" xml:space="preserve">
-    <value>Map failed to load</value>
+    <value>Map Failed to Load</value>
   </data>
   <data name="DeleteConfirmationAttachment_Message" xml:space="preserve">
     <value>This will remove the attachment from the database permanently and cannot be undone once the changes are saved.</value>
@@ -298,19 +298,19 @@
     <value>Are you sure you want to delete this attachment?</value>
   </data>
   <data name="AddAttachment_Tooltip" xml:space="preserve">
-    <value>Add attchment</value>
+    <value>Add Attachment</value>
   </data>
   <data name="DeleteAttachment_Tooltip" xml:space="preserve">
-    <value>Delete attachment</value>
+    <value>Delete Attachment</value>
   </data>
   <data name="FileNotFound_Message" xml:space="preserve">
     <value>The attachment file you are trying to open could not be located. Please try restarting the application.</value>
   </data>
   <data name="FileNotFound_Title" xml:space="preserve">
-    <value>File not found</value>
+    <value>File Not Found</value>
   </data>
   <data name="OpenAttachment_Tooltip" xml:space="preserve">
-    <value>Open attachment</value>
+    <value>Open Attachment</value>
   </data>
   <data name="CancelButton.Content" xml:space="preserve">
     <value>Cancel</value>
@@ -331,13 +331,13 @@
     <value>The attachment name has been truncated to 40 characters.</value>
   </data>
   <data name="AttachmentRenamedForLength_Title" xml:space="preserve">
-    <value>Attachment name too long</value>
+    <value>Attachment Name Too Long</value>
   </data>
   <data name="InvalidAttachmentExtension_Message" xml:space="preserve">
     <value>That attachment can't be added because the file type is unsupported.</value>
   </data>
   <data name="SavingEditsWait_Message" xml:space="preserve">
-    <value>Saving edits, please wait</value>
+    <value>Saving Edits, Please Wait</value>
   </data>
   <data name="ExpiredSignInToken_Message" xml:space="preserve">
     <value>Your login has expired. Please sign in again when prompted.</value>
@@ -346,6 +346,6 @@
     <value>Login Expired</value>
   </data>
   <data name="NoAttachmentsFound_Message" xml:space="preserve">
-    <value>No attachments found.</value>
+    <value>No Attachments</value>
   </data>
 </root>

--- a/src/DataCollection.UWP/LocalizedStrings/Resources.resw
+++ b/src/DataCollection.UWP/LocalizedStrings/Resources.resw
@@ -208,7 +208,7 @@
     <value>Error Retrieving Application Settings</value>
   </data>
   <data name="SerializationError_Title" xml:space="preserve">
-    <value>Error While Saving Application Settings</value>
+    <value>Error Saving Application Settings</value>
   </data>
   <data name="AddFeatureLabel_Line1.Text" xml:space="preserve">
     <value>Choose the location where you would like to add a feature.</value>
@@ -337,7 +337,7 @@
     <value>That attachment can't be added because the file type is unsupported.</value>
   </data>
   <data name="SavingEditsWait_Message" xml:space="preserve">
-    <value>Saving Edits, Please Wait</value>
+    <value>Saving edits, please wait.</value>
   </data>
   <data name="ExpiredSignInToken_Message" xml:space="preserve">
     <value>Your login has expired. Please sign in again when prompted.</value>

--- a/src/DataCollection.UWP/MainPage.xaml
+++ b/src/DataCollection.UWP/MainPage.xaml
@@ -70,6 +70,7 @@
                                     Content="&#xE711;"
                                     FontFamily="Segoe MDL2 Assets"
                                     FontSize="12"
+                                    Visibility="{TemplateBinding Tag}"
                                     Foreground="{TemplateBinding CloseButtonForeground}"
                                     ToolTipService.ToolTip="Close"/>
                     </Grid>
@@ -374,6 +375,7 @@
                 x:Name="IdentifiedFeatureBlade"
                 Header="{x:Bind MainViewModel.IdentifiedFeatureViewModel.PopupManager.Title, Mode=OneWay}"
                 IsOpen="{x:Bind MainViewModel.IdentifiedFeatureViewModel, Mode=OneWay, Converter={StaticResource NullToBoolConverter}}"
+                Tag="{x:Bind MainViewModel.IdentifiedFeatureViewModel.EditViewModel, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverse}"
                 Template="{StaticResource BladeItemTemplate}">
                 <views:IdentifiedFeaturePopup DataContext="{x:Bind MainViewModel, Mode=OneWay}" />
             </controls:BladeItem>
@@ -383,6 +385,7 @@
                 Expanded="BladeItem_Expanded"
                 Header="{x:Bind MainViewModel.IdentifiedFeatureViewModel.SelectedOriginRelationship.PopupManager.Title, Mode=OneWay}"
                 IsOpen="{x:Bind MainViewModel.IdentifiedFeatureViewModel.SelectedOriginRelationship, Mode=OneWay, Converter={StaticResource NullToBoolConverter}}"
+                Tag="{x:Bind MainViewModel.IdentifiedFeatureViewModel.SelectedOriginRelationship.EditViewModel, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverse}"
                 Template="{StaticResource BladeItemTemplate}">
                 <views:OriginRelatedRecordPopup DataContext="{x:Bind MainViewModel, Mode=OneWay}" />
             </controls:BladeItem>
@@ -390,6 +393,7 @@
                 x:Name="DestinationRelationshipBlade"
                 Header="{x:Bind MainViewModel.IdentifiedFeatureViewModel.SelectedDestinationRelationship.PopupManager.Title, Mode=OneWay}"
                 IsOpen="{x:Bind MainViewModel.IdentifiedFeatureViewModel.SelectedDestinationRelationship, Mode=OneWay, Converter={StaticResource NullToBoolConverter}}"
+                Tag="{x:Bind MainViewModel.IdentifiedFeatureViewModel.SelectedDestinationRelationship.EditViewModel, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverse}"
                 Template="{StaticResource BladeItemTemplate}">
                 <views:DestinationRelatedRecordPopup DataContext="{x:Bind MainViewModel.IdentifiedFeatureViewModel, Mode=OneWay}" />
             </controls:BladeItem>

--- a/src/DataCollection.UWP/Views/AttachmentsView.xaml
+++ b/src/DataCollection.UWP/Views/AttachmentsView.xaml
@@ -64,7 +64,7 @@
                         <Image 
                             Grid.Column="0"
                             Grid.Row="0" Grid.RowSpan="2"
-                            Height="40" Width="40"
+                            Height="45" Width="45"
                             Source="{Binding Thumbnail, Mode=OneWay}" />                        
                         <TextBlock
                             Grid.Column="1"
@@ -72,7 +72,7 @@
                             VerticalAlignment="Center"
                             Text="{Binding Attachment.Name, Mode=OneWay}"
                             FontWeight="SemiBold"
-                            TextWrapping="NoWrap" />
+                            TextWrapping="Wrap" />
                         <TextBlock 
                             Grid.Row="1" Grid.Column="1"
                             Text="{Binding Attachment.Size, Converter={StaticResource BytesToHumanReadableSizeConverter}}"

--- a/src/DataCollection.UWP/Views/AttachmentsView.xaml
+++ b/src/DataCollection.UWP/Views/AttachmentsView.xaml
@@ -33,7 +33,7 @@
         <ListView x:Name="AttachmentsItemsControl"
                   Grid.Row="1"
                   ItemsSource="{Binding AttachmentsViewModel.Attachments, Mode=OneWay}"
-                  Visibility="{Binding AttachmentsViewModel.Attachments, Mode=OneWay, Converter={StaticResource EmptyCollectionToVisibilityConverter},ConverterParameter='Inverse'}"
+                  Visibility="{Binding AttachmentsViewModel.HasAttachments, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                   SelectionMode="None">
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">
@@ -108,6 +108,6 @@
                    VerticalAlignment="Center"
                    Text="{x:Bind Converter={StaticResource LocalizationConverter}, ConverterParameter=NoAttachmentsFound_Message}" 
                    Style="{ThemeResource SubtitleTextBlockStyle}"
-                   Visibility="{Binding AttachmentsViewModel.Attachments, Mode=OneWay, Converter={StaticResource EmptyCollectionToVisibilityConverter}}" />
+                   Visibility="{Binding AttachmentsViewModel.HasAttachments, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter='Inverse'}" />
     </Grid>
 </UserControl>

--- a/src/DataCollection.UWP/Views/AttachmentsView.xaml
+++ b/src/DataCollection.UWP/Views/AttachmentsView.xaml
@@ -50,7 +50,7 @@
             </ListView.ItemContainerStyle>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:StagedAttachment">
-                    <Grid HorizontalAlignment="Stretch" ColumnSpacing="10">
+                    <Grid HorizontalAlignment="Stretch" ColumnSpacing="10" Margin="0,10,0,0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
@@ -64,12 +64,12 @@
                         <Image 
                             Grid.Column="0"
                             Grid.Row="0" Grid.RowSpan="2"
-                            Height="45" Width="45"
+                            Height="40" Width="40" VerticalAlignment="Center"
                             Source="{Binding Thumbnail, Mode=OneWay}" />                        
                         <TextBlock
                             Grid.Column="1"
                             Grid.Row="0"
-                            VerticalAlignment="Center"
+                            VerticalAlignment="Top"
                             Text="{Binding Attachment.Name, Mode=OneWay}"
                             FontWeight="SemiBold"
                             TextWrapping="Wrap" />

--- a/src/DataCollection.UWP/Views/IdentifiedFeaturePopup.xaml
+++ b/src/DataCollection.UWP/Views/IdentifiedFeaturePopup.xaml
@@ -287,10 +287,19 @@
         <CommandBar Grid.Row="1">
             <CommandBar.Content>
                 <!--  Add Attachment Button  -->
-                <AppBarButton Command="{x:Bind IdentifiedFeatureViewModel.EditFeatureCommand, Mode=OneWay}" 
-                              Icon="Attach"
+                <AppBarButton Command="{x:Bind IdentifiedFeatureViewModel.EditFeatureCommand, Mode=OneWay}"
                               ToolTipService.ToolTip="{x:Bind Converter={StaticResource LocalizationConverter}, ConverterParameter=AddAttachment_Tooltip}"
                               Label="Add Attachment" LabelPosition="Collapsed">
+                    <AppBarButton.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       FontSize="20"
+                                       Text="&#xE723;" />
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       FontSize="10"
+                                       Text="&#xE710;" />
+                        </StackPanel>
+                    </AppBarButton.Content>
                     <interactivity:Interaction.Behaviors>
                         <core:EventTriggerBehavior EventName="Click">
                             <core:ChangePropertyAction

--- a/src/DataCollection.UWP/Views/OriginRelatedRecordPopup.xaml
+++ b/src/DataCollection.UWP/Views/OriginRelatedRecordPopup.xaml
@@ -61,9 +61,18 @@
         <CommandBar Grid.Row="1">
             <CommandBar.Content>
                 <!--  Add Attachment Button  -->
-                <AppBarButton Icon="Attach"
-                              ToolTipService.ToolTip="{x:Bind Converter={StaticResource LocalizationConverter}, ConverterParameter=AddAttachment_Tooltip}"
+                <AppBarButton ToolTipService.ToolTip="{x:Bind Converter={StaticResource LocalizationConverter}, ConverterParameter=AddAttachment_Tooltip}"
                               Command="{x:Bind IdentifiedFeatureViewModel.SelectedOriginRelationship.EditRelatedRecordCommand, Mode=OneWay}" >
+                    <AppBarButton.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       FontSize="20"
+                                       Text="&#xE723;" />
+                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                       FontSize="10"
+                                       Text="&#xE710;" />
+                        </StackPanel>
+                    </AppBarButton.Content>
                     <interactivity:Interaction.Behaviors>
                         <core:EventTriggerBehavior EventName="Click">
                             <core:ChangePropertyAction

--- a/src/DataCollection.WPF/LocalizedStrings/Resources.resx
+++ b/src/DataCollection.WPF/LocalizedStrings/Resources.resx
@@ -348,4 +348,7 @@
   <data name="NoAttachmentsFound_Message" xml:space="preserve">
     <value>No Attachments</value>
   </data>
+  <data name="UnsupportedAttachment_Message" xml:space="preserve">
+    <value>Couldn't open that attachment because it isn't supported.</value>
+  </data>
 </root>

--- a/src/DataCollection.WPF/LocalizedStrings/Resources.resx
+++ b/src/DataCollection.WPF/LocalizedStrings/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AuthError_Title" xml:space="preserve">
-    <value>Authentication error</value>
+    <value>Authentication Error</value>
   </data>
   <data name="DiscardEditsConfirmation_Message" xml:space="preserve">
     <value>This will quit your edit sessions and will cause all of your unsaved changes to be lost.</value>
@@ -127,7 +127,7 @@
     <value>Are you sure you want to discard changes?</value>
   </data>
   <data name="ConditionDBH_UpdateError_Title" xml:space="preserve">
-    <value>Unable to update Condition &amp; DBH</value>
+    <value>Unable to Update Condition &amp; DBH</value>
   </data>
   <data name="DeleteConfirmation_Message" xml:space="preserve">
     <value>This will remove the feature from the database permanently and cannot be undone.</value>
@@ -136,16 +136,16 @@
     <value>Are you sure you want to delete this feature?</value>
   </data>
   <data name="GetFeatureRelationshipError_Message" xml:space="preserve">
-    <value>An error occured when attempting to retrieve relationships for the feature.</value>
+    <value>An error occurred when attempting to retrieve relationships for the feature.</value>
   </data>
   <data name="InvalidInput_Message" xml:space="preserve">
     <value>Changes to this record are invalid. Please correct and retry saving.</value>
   </data>
   <data name="InvalidInput_Title" xml:space="preserve">
-    <value>Invalid input detected</value>
+    <value>Invalid Input Detected</value>
   </data>
   <data name="SignInUnsuccessful_Title" xml:space="preserve">
-    <value>Sign in unsuccessful</value>
+    <value>Sign In Unsuccessful</value>
   </data>
   <data name="OperationCancelled" xml:space="preserve">
     <value>The operation was canceled.</value>
@@ -154,7 +154,7 @@
     <value>An error occured when attempting to retrieve related records for the feature.</value>
   </data>
   <data name="GenericError_Title" xml:space="preserve">
-    <value>An error has occured</value>
+    <value>An Error Occurred</value>
   </data>
   <data name="DeleteMap_Message" xml:space="preserve">
     <value>You will no longer have a map if you are in offline mode. </value>
@@ -163,13 +163,13 @@
     <value>Are you sure you want to delete the offline map?</value>
   </data>
   <data name="DownloadFailed_Title" xml:space="preserve">
-    <value>Download failed</value>
+    <value>Download Failed</value>
   </data>
   <data name="DownloadWithErrors_Title" xml:space="preserve">
-    <value>Download completed with errors</value>
+    <value>Download Completed with Errors</value>
   </data>
   <data name="IOException_Title" xml:space="preserve">
-    <value>IO exception</value>
+    <value>IO Exception</value>
   </data>
   <data name="DeleteMapWithUnsyncedChanges_Message" xml:space="preserve">
     <value>The offline map contains un-synchronized changes. You will no longer have a map when you are in offline mode and will lose your existing changes. </value>
@@ -187,7 +187,7 @@
     <value>Discard</value>
   </data>
   <data name="DeviceOffline_Title" xml:space="preserve">
-    <value>Device is offline</value>
+    <value>Device is Offline</value>
   </data>
   <data name="NoDelete_DeviceOffline_Message" xml:space="preserve">
     <value>Your device must be connected to a network to delete the offline map.</value>
@@ -202,19 +202,19 @@
     <value>The application was unable to delete the offline map and needs to restart. </value>
   </data>
   <data name="IdentifyError_Title" xml:space="preserve">
-    <value>Error while identifying feature</value>
+    <value>Error Occurred While Identifying Feature</value>
   </data>
   <data name="DeserializationError_Title" xml:space="preserve">
-    <value>Error retrieving application settings</value>
+    <value>Error Retrieving Application Settings</value>
   </data>
   <data name="SerializationError_Title" xml:space="preserve">
-    <value>Error saving application settings</value>
+    <value>Error While Saving Application Settings</value>
   </data>
   <data name="AddFeatureLabel_Line1.Text" xml:space="preserve">
-    <value>Choose the location where you would like to add a feature</value>
+    <value>Choose the location where you would like to add a feature.</value>
   </data>
   <data name="AddFeatureLabel_Line2.Text" xml:space="preserve">
-    <value>Pan and zoom map under pin</value>
+    <value>Pan and zoom map under pin.</value>
   </data>
   <data name="AddFeatureButton.Label" xml:space="preserve">
     <value>Add Feature</value>
@@ -241,10 +241,10 @@
     <value>Preparing map for offline use. Please wait.</value>
   </data>
   <data name="DownloadLabel_Line1.Text" xml:space="preserve">
-    <value>Select the region of the map to take offline</value>
+    <value>Select the region of the map to take offline.</value>
   </data>
   <data name="DownloadLabel_Line2.Text" xml:space="preserve">
-    <value>Pan and zoom map within rectangle</value>
+    <value>Pan and zoom map within the rectangle.</value>
   </data>
   <data name="EditRecord_Tooltip" xml:space="preserve">
     <value>Edit Record</value>
@@ -289,7 +289,7 @@
     <value>Center on Location</value>
   </data>
   <data name="MapLoadingError_Title" xml:space="preserve">
-    <value>Map failed to load</value>
+    <value>Map Failed to Load</value>
   </data>
   <data name="DeleteConfirmationAttachment_Message" xml:space="preserve">
     <value>This will remove the attachment from the database permanently and cannot be undone once the changes are saved.</value>
@@ -298,19 +298,19 @@
     <value>Are you sure you want to delete this attachment?</value>
   </data>
   <data name="AddAttachment_Tooltip" xml:space="preserve">
-    <value>Add attchment</value>
+    <value>Add Attachment</value>
   </data>
   <data name="DeleteAttachment_Tooltip" xml:space="preserve">
-    <value>Delete attachment</value>
+    <value>Delete Attachment</value>
   </data>
   <data name="FileNotFound_Message" xml:space="preserve">
     <value>The attachment file you are trying to open could not be located. Please try restarting the application.</value>
   </data>
   <data name="FileNotFound_Title" xml:space="preserve">
-    <value>File not found</value>
+    <value>File Not Found</value>
   </data>
   <data name="OpenAttachment_Tooltip" xml:space="preserve">
-    <value>Open attachment</value>
+    <value>Open Attachment</value>
   </data>
   <data name="CancelButton.Content" xml:space="preserve">
     <value>Cancel</value>
@@ -331,13 +331,13 @@
     <value>The attachment name has been truncated to 40 characters.</value>
   </data>
   <data name="AttachmentRenamedForLength_Title" xml:space="preserve">
-    <value>Attachment name too long</value>
+    <value>Attachment Name Too Long</value>
   </data>
   <data name="InvalidAttachmentExtension_Message" xml:space="preserve">
     <value>That attachment can't be added because the file type is unsupported.</value>
   </data>
   <data name="SavingEditsWait_Message" xml:space="preserve">
-    <value>Saving edits, please wait</value>
+    <value>Saving Edits, Please Wait</value>
   </data>
   <data name="ExpiredSignInToken_Message" xml:space="preserve">
     <value>Your login has expired. Please sign in again when prompted.</value>
@@ -346,6 +346,6 @@
     <value>Login Expired</value>
   </data>
   <data name="NoAttachmentsFound_Message" xml:space="preserve">
-    <value>No attachments found.</value>
+    <value>No Attachments</value>
   </data>
 </root>

--- a/src/DataCollection.WPF/LocalizedStrings/Resources.resx
+++ b/src/DataCollection.WPF/LocalizedStrings/Resources.resx
@@ -208,7 +208,7 @@
     <value>Error Retrieving Application Settings</value>
   </data>
   <data name="SerializationError_Title" xml:space="preserve">
-    <value>Error While Saving Application Settings</value>
+    <value>Error Saving Application Settings</value>
   </data>
   <data name="AddFeatureLabel_Line1.Text" xml:space="preserve">
     <value>Choose the location where you would like to add a feature.</value>
@@ -337,7 +337,7 @@
     <value>That attachment can't be added because the file type is unsupported.</value>
   </data>
   <data name="SavingEditsWait_Message" xml:space="preserve">
-    <value>Saving Edits, Please Wait</value>
+    <value>Saving edits, please wait.</value>
   </data>
   <data name="ExpiredSignInToken_Message" xml:space="preserve">
     <value>Your login has expired. Please sign in again when prompted.</value>

--- a/src/DataCollection.WPF/MainWindow.xaml
+++ b/src/DataCollection.WPF/MainWindow.xaml
@@ -253,64 +253,61 @@
             <Grid.Effect>
                 <DropShadowEffect BlurRadius="20" Opacity=".5" />
             </Grid.Effect>
-            <StackPanel
+            <Grid
                 x:Name="AuthStackPanel"
                 Grid.Row="0"
-                Background="Green"
-                Orientation="Horizontal">
-                <Ellipse
-                    Width="50"
-                    Height="50"
+                Background="Green">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Ellipse Grid.Column="0"
+                    Width="40"
+                    Height="40"
                     Margin="10"
-                    Visibility="{Binding AuthenticatedUser, Converter={StaticResource NullToVisibilityConverter}}">
+                    Visibility="{Binding AuthenticatedUser.ThumbnailUri, Converter={StaticResource NullToVisibilityConverter}}">
                     <Ellipse.Fill>
                         <ImageBrush ImageSource="{Binding AuthenticatedUser.ThumbnailUri}" />
                     </Ellipse.Fill>
                 </Ellipse>
-                <TextBlock
-                    Margin="10,0,10,0"
-                    VerticalAlignment="Center"
+                <TextBlock Grid.Column="0"
+                    Margin="10"
+                    VerticalAlignment="Center" HorizontalAlignment="Center"
                     FontFamily="Segoe MDL2 Assets"
                     FontSize="25"
                     Foreground="White"
                     Text="&#xE77B;"
-                    Visibility="{Binding AuthenticatedUser, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverse}" />
+                    Visibility="{Binding AuthenticatedUser.ThumbnailUri, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverse}" />
 
                 <!--  Sign In Button  -->
-                <Button
-                    Margin="0,0,10,0"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Center"
+                <Button Grid.Column="1" Padding="10"
+                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
                     Command="{Binding SignInCommand}"
                     Content="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=SignInButton.Label}"
                     FontSize="25"
                     Style="{StaticResource MenuButtonStyle}"
                     Visibility="{Binding AuthenticatedUser, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverse}" />
 
-                <!--  Sing Out Button  -->
-                <Button
-                    Margin="0,0,10,0"
-                    HorizontalAlignment="Center"
+                <!--  Sign Out Button  -->
+                <Button Grid.Column="1" Padding="10"
+                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
                     Command="{Binding SignOutCommand}"
                     FontSize="25"
                     Style="{StaticResource MenuButtonStyle}"
                     Visibility="{Binding AuthenticatedUser, Converter={StaticResource NullToVisibilityConverter}}">
                     <StackPanel Orientation="Vertical">
                         <TextBlock
-                            Margin="0,0,10,0"
-                            Padding="5"
                             VerticalAlignment="Center"
                             FontSize="25"
                             Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=SignOutButton.Label}" />
                         <TextBlock
-                            Padding="15,0,15,5"
-                            VerticalAlignment="Center"
-                            FontSize="10"
+                            Margin="0,5,0,0"
+                            FontSize="12"
                             Foreground="White"
                             Text="{Binding AuthenticatedUser.FullName}" />
                     </StackPanel>
                 </Button>
-            </StackPanel>
+            </Grid>
 
             <StackPanel
                 Grid.Row="1"
@@ -318,53 +315,49 @@
                 Orientation="Vertical">
                 <!--  Working online button and text  -->
                 <Button
-                    Margin="15,5,15,5"
-                    HorizontalAlignment="Left"
-                    Background="#C37534"
+                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
+                    Padding="10"
+                    Background="{StaticResource Button.Pressed.Background}"
                     Style="{StaticResource MenuButtonStyle}"
                     Visibility="{Binding ConnectivityMode, Converter={StaticResource ConnectivityModeToVisibilityConverter}}">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Margin="10,0,0,0"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            FontFamily="Segoe MDL2 Assets"
-                            FontSize="25"
-                            Text="&#xEC3F;" />
-                        <TextBlock
-                            Margin="0,0,10,0"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            FontSize="19"
-                            Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=WorkingOnlineButton.Label}" />
-                    </StackPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Style="{StaticResource MenuButtonIconStyle}"
+                                   Grid.Column="0"
+                                   Text="&#xEC3F;" />
+                        <TextBlock VerticalAlignment="Center"
+                                   Grid.Column="1"
+                                   FontSize="19"
+                                   Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=WorkingOnlineButton.Label}" />
+                    </Grid>
                 </Button>
 
                 <!--  Work online button and text  -->
                 <Button
-                    Margin="15,5,15,5"
-                    HorizontalAlignment="Left"
+                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
+                    Padding="10"
                     Background="White"
                     Command="{Binding WorkOnlineCommand}"
                     CommandParameter="{Binding ElementName=MapView, Path=VisibleArea}"
                     Foreground="Black"
                     Style="{StaticResource MenuButtonStyle}"
                     Visibility="{Binding ConnectivityMode, Converter={StaticResource ConnectivityModeToVisibilityConverter}, ConverterParameter=Inverse}">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Margin="10,0,0,0"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            FontFamily="Segoe MDL2 Assets"
-                            FontSize="25"
-                            Text="&#xEC3F;" />
-                        <TextBlock
-                            Margin="0,0,10,0"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            FontSize="19"
-                            Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=WorkOnlineButton.Label}" />
-                    </StackPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Style="{StaticResource MenuButtonIconStyle}"
+                                   Grid.Column="0"
+                                   Text="&#xEC3F;" />
+                        <TextBlock VerticalAlignment="Center"
+                                   Grid.Column="1"
+                                   FontSize="19"
+                                   Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=WorkOnlineButton.Label}" />
+                    </Grid>
                     <i:Interaction.Triggers>
                         <i:EventTrigger EventName="Click">
                             <i:ChangePropertyAction
@@ -378,52 +371,48 @@
 
                 <!--  Working offline button and text  -->
                 <Button
-                    Margin="15,5,15,5"
-                    HorizontalAlignment="Left"
-                    Background="#C37534"
+                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
+                    Padding="10"
+                    Background="{StaticResource Button.Pressed.Background}"
                     Style="{StaticResource MenuButtonStyle}"
                     Visibility="{Binding ConnectivityMode, Converter={StaticResource ConnectivityModeToVisibilityConverter}, ConverterParameter=Inverse}">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Margin="10,0,0,0"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            FontFamily="Segoe MDL2 Assets"
-                            FontSize="25"
-                            Text="&#xEB5E;" />
-                        <TextBlock
-                            Margin="0,0,10,0"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            FontSize="19"
-                            Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=WorkingOfflineButton.Label}" />
-                    </StackPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Style="{StaticResource MenuButtonIconStyle}"
+                                   Grid.Column="0"
+                                   Text="&#xEB5E;" />
+                        <TextBlock Grid.Column="1"
+                                   VerticalAlignment="Center"
+                                   FontSize="19"
+                                   Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=WorkingOfflineButton.Label}" />
+                    </Grid>
                 </Button>
 
                 <!--  Work offline button and text  -->
                 <Button
-                    Margin="15,5,15,5"
-                    HorizontalAlignment="Left"
+                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
+                    Padding="10"
                     Background="White"
                     Command="{Binding WorkOfflineCommand}"
                     Foreground="Black"
                     Style="{StaticResource MenuButtonStyle}"
                     Visibility="{Binding ConnectivityMode, Converter={StaticResource ConnectivityModeToVisibilityConverter}}">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Margin="10,0,0,0"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            FontFamily="Segoe MDL2 Assets"
-                            FontSize="25"
-                            Text="&#xEB5E;" />
-                        <TextBlock
-                            Margin="0,0,10,0"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            FontSize="19"
-                            Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=WorkOfflineButton.Label}" />
-                    </StackPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Style="{StaticResource MenuButtonIconStyle}"
+                                   Grid.Column="0"
+                                   Text="&#xEB5E;" />
+                        <TextBlock Grid.Column="1"
+                                   VerticalAlignment="Center"
+                                   FontSize="19"
+                                   Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=WorkOfflineButton.Label}" />
+                    </Grid>
                     <i:Interaction.Triggers>
                         <i:EventTrigger EventName="Click">
                             <i:ChangePropertyAction
@@ -436,35 +425,34 @@
 
                 <!--  Synchronize button and text  -->
                 <Button
-                    Margin="15,5,15,5"
-                    HorizontalAlignment="Left"
+                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
+                    Padding="10"
                     Background="White"
                     Command="{Binding SyncMapCommand}"
                     Foreground="Black"
                     Style="{StaticResource MenuButtonStyle}"
                     Visibility="{Binding OfflineMap, Converter={StaticResource NullToVisibilityConverter}}">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Margin="10,0,0,0"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            FontFamily="Segoe MDL2 Assets"
-                            FontSize="25"
-                            Foreground="Black"
-                            Text="&#xE895;" />
-                        <StackPanel Orientation="Vertical">
-                            <TextBlock
-                                Margin="0,0,10,0"
-                                Padding="5"
-                                VerticalAlignment="Center"
-                                FontSize="19"
-                                Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=SyncButton.Label}" />
-                            <TextBlock
-                                HorizontalAlignment="Center"
-                                FontSize="10"
-                                Text="{Binding SyncDate}" />
-                        </StackPanel>
-                    </StackPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <TextBlock Style="{StaticResource MenuButtonIconStyle}"
+                                   Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
+                                   Text="&#xE895;" />
+                        <TextBlock Grid.Row="0" Grid.Column="1"
+                                   VerticalAlignment="Center"
+                                   FontSize="19"
+                                   Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=SyncButton.Label}" />
+                        <TextBlock Grid.Row="1" Grid.Column="1"
+                                   HorizontalAlignment="Right"
+                                   FontSize="12"
+                                   Text="{Binding SyncDate}" />
+                    </Grid>
                     <i:Interaction.Triggers>
                         <i:EventTrigger EventName="Click">
                             <i:ChangePropertyAction
@@ -477,28 +465,26 @@
 
                 <!--  Delete offline map button and text  -->
                 <Button
-                    Margin="15,5,15,5"
-                    HorizontalAlignment="Left"
+                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
+                    Padding="10"
                     Background="White"
                     Command="{Binding DeleteOfflineMapCommand}"
                     Foreground="Black"
                     Style="{StaticResource MenuButtonStyle}"
                     Visibility="{Binding OfflineMap, Converter={StaticResource NullToVisibilityConverter}}">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Margin="10,0,0,0"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            FontFamily="Segoe MDL2 Assets"
-                            FontSize="25"
-                            Text="&#xE74D;" />
-                        <TextBlock
-                            Margin="0,0,10,0"
-                            Padding="5"
-                            VerticalAlignment="Center"
-                            FontSize="19"
-                            Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=DeleteMapButton.Label}" />
-                    </StackPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Style="{StaticResource MenuButtonIconStyle}"
+                                   Grid.Column="0"
+                                   Text="&#xE74D;" />
+                        <TextBlock Grid.Column="1"
+                                   VerticalAlignment="Center"
+                                   FontSize="19"
+                                   Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=DeleteMapButton.Label}" />
+                    </Grid>
                     <i:Interaction.Triggers>
                         <i:EventTrigger EventName="Click">
                             <i:ChangePropertyAction

--- a/src/DataCollection.WPF/ResourceDictionary.xaml
+++ b/src/DataCollection.WPF/ResourceDictionary.xaml
@@ -30,6 +30,7 @@
     <SolidColorBrush x:Key="Button.Pressed.Background" Color="#C37534" />
     <SolidColorBrush x:Key="Button.Pressed.Border" Color="DarkGreen" />
     <SolidColorBrush x:Key="Button.Disabled.Foreground" Color="LightGray" />
+    <SolidColorBrush x:Key="Window.Background" Color="White" />
 
     <Style x:Key="MenuButtonStyle" TargetType="{x:Type Button}">
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}" />

--- a/src/DataCollection.WPF/ResourceDictionary.xaml
+++ b/src/DataCollection.WPF/ResourceDictionary.xaml
@@ -82,6 +82,12 @@
         </Setter>
         <Setter Property="BorderThickness" Value="0" />
     </Style>
+    <Style x:Key="MenuButtonIconStyle" TargetType="TextBlock">
+        <Setter Property="Margin" Value="0,0,5,0" />
+        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="FontSize" Value="25" />
+        <Setter Property="FontFamily" Value="Segoe MDL2 Assets" />
+    </Style>
 
     <Style x:Key="ToggleButtonStyle" TargetType="{x:Type ToggleButton}">
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}" />

--- a/src/DataCollection.WPF/Views/AttachmentsView.xaml
+++ b/src/DataCollection.WPF/Views/AttachmentsView.xaml
@@ -37,7 +37,7 @@
                   Grid.Row="1"
                   ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                   ItemsSource="{Binding AttachmentsViewModel.Attachments}"
-                  Visibility="{Binding AttachmentsViewModel.Attachments, Converter={StaticResource EmptyCollectionToVisibilityConverter}, ConverterParameter='Inverse'}">
+                  Visibility="{Binding AttachmentsViewModel.HasAttachments, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
             <ListView.ItemContainerStyle>
                 <Style TargetType="{x:Type ListViewItem}">
                     <Setter Property="Template">
@@ -118,7 +118,7 @@
                    HorizontalAlignment="Center"
                    VerticalAlignment="Center"
                    Text="{Binding ., Converter={StaticResource LocalizationConverter}, ConverterParameter=NoAttachmentsFound_Message}" 
-                   Visibility="{Binding AttachmentsViewModel.Attachments, Mode=OneWay, Converter={StaticResource EmptyCollectionToVisibilityConverter}}"
+                   Visibility="{Binding AttachmentsViewModel.HasAttachments, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter='Inverse'}"
                    FontWeight="SemiBold"
                    Margin="15" />
     </Grid>

--- a/src/DataCollection.WPF/Views/AttachmentsView.xaml
+++ b/src/DataCollection.WPF/Views/AttachmentsView.xaml
@@ -19,7 +19,7 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Grid>
+    <Grid Background="{StaticResource Window.Background}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />

--- a/src/DataCollection.WPF/Views/AttachmentsView.xaml
+++ b/src/DataCollection.WPF/Views/AttachmentsView.xaml
@@ -73,7 +73,7 @@
                             Grid.Row="0"
                             FontWeight="SemiBold"
                             Text="{Binding Attachment.Name}"
-                            TextWrapping="NoWrap" />
+                            TextWrapping="Wrap" />
                         <TextBlock
                             Grid.Column="1"
                             Grid.Row="1"


### PR DESCRIPTION
This PR addresses the following issues:

* #80 - now attachment name is wrapped
* #79 - now when a file fails to launch on UWP, it should show the app picker dialog
* #77 - I'm now explicitly setting the background on the Attachments view grid; I'll need verification that this fix works, as it was already defaulting to white on my devices. I think that bug may have been triggered by Remote Desktop. 
* #34 - switch to title case and fix spelling in several areas
* In identified feature popup, use Attachment with + icon in UWP to match WPF appearance
* On UWP, hide the popup close button when editing.
* Fixes issue where UWP wouldn't open attachments without a file extension
* #83 Fixes issue where the first attachment added to a feature doesn't initially display.
* Fixes issue where the 'No attachments' message isn't shown when all attachments are deleted