### PR TITLE
Bug fix: issue when adding features

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@
 * Updates doc and many code comments to avoid all use of `http:`.
 * Updates ArcGIS Runtime to 100.10.
 * Fixes warnings related to deprecated APIs and other issues.
+* Fixes an issue that would prevent addition of new features in some circumstances.
 
 ## 1.2.3
 

--- a/src/DataCollection.Shared/ViewModels/MainViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/MainViewModel.cs
@@ -751,65 +751,70 @@ namespace Esri.ArcGISRuntime.OpenSourceApps.DataCollection.Shared.ViewModels
                     {
                         IsAddingFeature = false;
                         IsLocationOnlyMode = false;
+                        // Note: will try to add to each point feature layer; keeps trying if there is an exception;
+                        // if the feature cannot be added, aggregate exception thrown
+                        var innerExceptions = new List<Exception>();
                         // specifying the first points layer as the target of the Add operation
                         // lines and polygons are not supported in this version of the app
                         // adding to multiple layers in not supported in this version of the app
-                        foreach (var layer in MapViewModel.Map.OperationalLayers)
+                        foreach (var layer in MapViewModel.Map.OperationalLayers.OfType<FeatureLayer>().Where(layer => layer.FeatureTable.GeometryType == GeometryType.Point))
                         {
                             // check to see that layer is identifiable based on the app rules
-                            if (layer is FeatureLayer featureLayer)
+                            try
                             {
-                                try
-                                {
-                                    // create new feature 
-                                    var feature = featureLayer.FeatureTable.CreateFeature();
+                                // create new feature 
+                                var feature = layer.FeatureTable.CreateFeature();
 
-                                    // set feature geometry as the pinpoint's position
-                                    var frameworkElement = (FrameworkElement)pinpointElement;
+                                // set feature geometry as the pinpoint's position
+                                var frameworkElement = (FrameworkElement)pinpointElement;
                                     
-                                    MapPoint newFeatureGeometry = null;
+                                MapPoint newFeatureGeometry = null;
 #if WPF
-                                    var point = new Point(frameworkElement.Width / 2, frameworkElement.Height / 2);
-                                    newFeatureGeometry = MapAccessoryViewModel.MapView.ScreenToLocation(frameworkElement.TranslatePoint(point, MapAccessoryViewModel.MapView));
+                                var point = new Point(frameworkElement.Width / 2, frameworkElement.Height / 2);
+                                newFeatureGeometry = MapAccessoryViewModel.MapView.ScreenToLocation(frameworkElement.TranslatePoint(point, MapAccessoryViewModel.MapView));
 #elif NETFX_CORE
-                                    var transform = frameworkElement.TransformToVisual(MapAccessoryViewModel.MapView);
-                                    // Get the actual center point. CenterPoint here defaults to top left
-                                    var point = new Point(frameworkElement.CenterPoint.X + frameworkElement.Width / 2, frameworkElement.CenterPoint.Y + frameworkElement.Height / 2);
-                                    newFeatureGeometry = MapAccessoryViewModel.MapView.ScreenToLocation(transform.TransformPoint(point));
+                                var transform = frameworkElement.TransformToVisual(MapAccessoryViewModel.MapView);
+                                // Get the actual center point. CenterPoint here defaults to top left
+                                var point = new Point(frameworkElement.CenterPoint.X + frameworkElement.Width / 2, frameworkElement.CenterPoint.Y + frameworkElement.Height / 2);
+                                newFeatureGeometry = MapAccessoryViewModel.MapView.ScreenToLocation(transform.TransformPoint(point));
 #else
-                                    throw new NotImplementedException();
+                                throw new NotImplementedException();
 #endif
 
-                                    // call method to perform custom workflow for the custom tree dataset
+                                // call method to perform custom workflow for the custom tree dataset
 #pragma warning disable CS0162 // Unreachable code detected
-                                    await TreeSurveyWorkflows.PerformNewTreeWorkflow(MapViewModel.Map.OperationalLayers, feature, newFeatureGeometry);
+                                await TreeSurveyWorkflows.PerformNewTreeWorkflow(MapViewModel.Map.OperationalLayers, feature, newFeatureGeometry);
 
-                                    // create the feature and its corresponding viewmodel
-                                    var featureVM = new IdentifiedFeatureViewModel(feature, ConnectivityMode, this)
-                                    {
-                                        EditViewModel = new EditViewModel(ConnectivityMode)
-                                    };
-                                    featureVM.EditViewModel.CreateFeature(newFeatureGeometry, feature as ArcGISFeature, featureVM.PopupManager);
-
-                                    //get relationship information for the newly added feature
-                                    await featureVM.GetRelationshipInfoForFeature(feature as ArcGISFeature);
-
-                                    // Add the feature to the table so that it is visible on the map.
-                                    await feature.FeatureTable.AddFeatureAsync(feature);
-
-                                    IdentifyResultViewModel.SetNewIdentifyResult(new List<IdentifiedFeatureViewModel>() { featureVM });
-
-                                    // select the new feature
-                                    MapViewModel.SelectFeature(feature);
-
-                                    break;
-#pragma warning restore CS0162 // Unreachable code detected
-                                }
-                                catch (Exception ex)
+                                // create the feature and its corresponding viewmodel
+                                var featureVM = new IdentifiedFeatureViewModel(feature, ConnectivityMode, this)
                                 {
-                                    UserPromptMessenger.Instance.RaiseMessageValueChanged(null, ex.Message, true, ex.StackTrace);
-                                }
+                                    EditViewModel = new EditViewModel(ConnectivityMode)
+                                };
+                                featureVM.EditViewModel.CreateFeature(newFeatureGeometry, feature as ArcGISFeature, featureVM.PopupManager);
+
+                                //get relationship information for the newly added feature
+                                await featureVM.GetRelationshipInfoForFeature(feature as ArcGISFeature);
+
+                                // Add the feature to the table so that it is visible on the map.
+                                await feature.FeatureTable.AddFeatureAsync(feature);
+
+                                IdentifyResultViewModel.SetNewIdentifyResult(new List<IdentifiedFeatureViewModel>() { featureVM });
+
+                                // select the new feature
+                                MapViewModel.SelectFeature(feature);
+
+                                return;
+#pragma warning restore CS0162 // Unreachable code detected
                             }
+                            catch (Exception ex)
+                            {
+                                innerExceptions.Add(ex);
+                            }
+                        }
+                        if (innerExceptions.Any())
+                        {
+                            var ex = new AggregateException(innerExceptions);
+                            UserPromptMessenger.Instance.RaiseMessageValueChanged(null, ex.Message, true, ex.StackTrace);
                         }
                     }));
             }

--- a/src/DataCollection.Shared/ViewModels/MainViewModel.cs
+++ b/src/DataCollection.Shared/ViewModels/MainViewModel.cs
@@ -805,7 +805,8 @@ namespace Esri.ArcGISRuntime.OpenSourceApps.DataCollection.Shared.ViewModels
                         }
                         catch (Exception ex)
                         {
-                            UserPromptMessenger.Instance.RaiseMessageValueChanged(null, ex.Message, true, ex.StackTrace);
+                            UserPromptMessenger.Instance.RaiseMessageValueChanged(Resources.GetString("AddFeatureError_Title"), 
+                                Resources.GetString("AddFeatureError_Message"), true, ex.StackTrace);
                         }
                     }));
             }

--- a/src/DataCollection.UWP/LocalizedStrings/Resources.resw
+++ b/src/DataCollection.UWP/LocalizedStrings/Resources.resw
@@ -534,4 +534,10 @@
   <data name="Error_LaunchURLFailed" xml:space="preserve">
     <value>Unable to start link</value>
   </data>
+  <data name="AddFeatureError_Message" xml:space="preserve">
+    <value>There was a problem while adding the feature. Verify that the web map has at least one editable feature layer with point geometry.</value>
+  </data>
+  <data name="AddFeatureError_Title" xml:space="preserve">
+    <value>Error adding feature</value>
+  </data>
 </root>

--- a/src/DataCollection.WPF_NetFramework/LocalizedStrings/Resources.resx
+++ b/src/DataCollection.WPF_NetFramework/LocalizedStrings/Resources.resx
@@ -534,4 +534,10 @@
   <data name="Error_LaunchURLFailed" xml:space="preserve">
     <value>Unable to start link</value>
   </data>
+  <data name="AddFeatureError_Message" xml:space="preserve">
+    <value>There was a problem while adding the feature. Verify that the web map has at least one editable feature layer with point geometry.</value>
+  </data>
+  <data name="AddFeatureError_Title" xml:space="preserve">
+    <value>Error adding feature</value>
+  </data>
 </root>


### PR DESCRIPTION
There must have been some sort of behavior change with the ordering of layers in the map. I don't think this qualifies as a bug in dependencies, since the code was making an invalid assumption that happened to work previously.

Previously, the code to add a feature would add to the first feature layer found, and throw an exception if that didn't work.

Now, the add method attempts to add to the first feature layer with point geometry. If there is an error, it keeps trying the rest of the point feature layers. Operation completes if feature can be added to any point layer. If feature cannot be added to any layer, an aggregate exception will be raised with any exceptions from adding to individual layers.

This isn't the most comprehensive solution, as it assumes there will always be at least one point feature layer. I think it makes sense to go with this temporary solution, since we will be updating to add multiple geometry support very soon, and that will require a complete rewrite of this method.